### PR TITLE
chore: Dockerfile, docker-compose.yml 을 통한 도커 테스트 초기 환경 세팅

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# [1] Build Stage
+FROM gradle:8.14.2-jdk17-alpine AS build
+WORKDIR /app
+
+COPY gradlew gradlew.bat ./
+COPY gradle ./gradle/
+COPY settings.gradle ./
+COPY build.gradle ./
+RUN chmod +x gradlew
+
+COPY src ./src
+
+RUN ./gradlew build -x test
+
+# [2] Runtime stage
+FROM eclipse-temurin:17-jre-alpine-3.21 AS runtime
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+CMD ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  backend:
+    container_name: mopl-container
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8080:8080
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - ./.env
+    environment:
+      - JVM_OPTS=-Xms256m -Xmx512m
+      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://db:${POSTGRES_PORT}/${POSTGRES_DB}
+      - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
+      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+      # REDIS, KAFKA 추가 시 환경변수 추가
+  db:
+    container_name: postgresDB
+    image: postgres:14-alpine
+    ports:
+      - 5432:5432
+    env_file:
+      - ./.env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:


### PR DESCRIPTION
## 🛰️ Issue Number

#11 

## 🪐 작업 내용

`docker-compose up -d` 명령어를 터미널에 작성하시면, 이미지 빌드와 컨테이너 띄우기를 할 수 있습니다. 
`docker-compose down` 명령어로 컨테이너를 내릴 수 있습니다.

![image](https://github.com/user-attachments/assets/c6d67567-dac8-403a-a50d-3aaecb781241)
![image](https://github.com/user-attachments/assets/1f195ecf-c5db-4676-94d6-b51b2038fa99)
![image](https://github.com/user-attachments/assets/062e27c8-ef30-4fda-8d84-609668a43380)

---

**<유의점 : 에러 발생 가능 지점>**

1. window 사용 팀원들 : **gradlew 개행모드 LF**로 바꾸셔야합니다.
  https://lightning-shell-5dc.notion.site/bin-sh-gradlew-bin-sh-M-bad-interpreter-No-such-file-or-directory-1d0ea008b61c80d6b82eee0192f2d1de?source=copy_link
2. **gradle-wrapper의 부재**
    `.gitignore` 을 통해서 모든 `.jar` 을 제외하고 있어서, `gradle-wrapper.jar` 파일이 없을 확률이 높습니다. → gradle을 PC에 설치하거나, 새 프로젝트를 만들어서 mopl 프로젝트 내부 `gradle/wrapper/` 하위에 `gradle-wrapper.jar` 를 복사 붙여넣기 하여 넣어주십쇼.
    
---

**<Check!!>**
1. 현재는 도커 컨테이너를 띄우기 위해 애플리케이션 build할 때 test를 꺼뒀습니다.
2. kafka, redis 도입 후 얘기가 오가면 Docker-compose.yml에도 kafka, redis 를 띄우는 코드를 추가하여 리팩토링하겠습니다.
3. `.env`, `application-dev.yaml` 은 노션에 업로드 해놓겠습니다.
4. 프론트코드와 연결 이전 초기 세팅 정도로만 생각해주시면 감사하겠습니다! (생각해보니 여태 정적 리소스가 있어서 처음부터 Docker로 실제 환경에서 테스트할 수 있었음을 잠시 잊고 있었던 것 같습니다...)

그외 오류는 언제든지 제보+알려주십쇼!


## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?