### PR TITLE
feat: 양방향 통신 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     // Prometheus
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    //websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/team03/mopl/domain/dm/config/WebSocketConfig.java
+++ b/src/main/java/team03/mopl/domain/dm/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package team03.mopl.domain.dm.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // WebSocket 연결용 엔드포인트
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+    //모든 웹소켓 연결을 허용할 것인지도 확인해봐야할 듯?
+  }
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    // 클라이언트가 구독할 경로 (ex: /topic/chat.room.{roomId})
+    registry.enableSimpleBroker("/topic");
+
+    // 클라이언트가 메시지를 보낼 때 사용할 prefix
+    registry.setApplicationDestinationPrefixes("/app");
+  }
+}

--- a/src/main/java/team03/mopl/domain/dm/controller/DmController.java
+++ b/src/main/java/team03/mopl/domain/dm/controller/DmController.java
@@ -1,0 +1,28 @@
+package team03.mopl.domain.dm.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team03.mopl.domain.dm.dto.DmDto;
+import team03.mopl.domain.dm.service.DmRoomService;
+import team03.mopl.domain.dm.service.DmService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dm")
+public class DmController {
+  private final DmService dmService;
+  private final DmRoomService dmRoomService;
+
+  // 유저가 룸안의 dm 메시지 가져오기 ( 커서 페이징 필요? )
+  @GetMapping("/{roomId}/dm")
+  public ResponseEntity<List<DmDto>> getDm(@PathVariable UUID roomId, @RequestParam UUID userId) {
+    return ResponseEntity.ok(dmService.getDmList(roomId, userId));
+  }
+}

--- a/src/main/java/team03/mopl/domain/dm/controller/DmRoomController.java
+++ b/src/main/java/team03/mopl/domain/dm/controller/DmRoomController.java
@@ -1,0 +1,48 @@
+package team03.mopl.domain.dm.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import team03.mopl.domain.dm.dto.DmRoomDto;
+import team03.mopl.domain.dm.service.DmRoomService;
+import team03.mopl.domain.dm.service.DmService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dmRooms")
+public class DmRoomController {
+  private final DmRoomService dmRoomService;
+  private final DmService dmService;
+
+  @GetMapping("/{dmRoomId}") // 룸 ID를 통한 조회
+  public ResponseEntity<DmRoomDto> getRoom(@PathVariable UUID dmRoomId) {
+    return ResponseEntity.ok(dmRoomService.getRoom(dmRoomId));
+  }
+  @GetMapping("/userRoom") // UserA와 UserB가 연결된 룸 조회 / 없으면 생성
+  public ResponseEntity<UUID> getOrCreateRoom(
+      @RequestParam UUID userA,
+      @RequestParam UUID userB
+  ) {
+    DmRoomDto dmRoomDto = dmRoomService.findOrCreateRoom(userA, userB);
+    return ResponseEntity.ok(dmRoomDto.getId());
+  }
+  @GetMapping("/") //유저의 모든 룸 조회
+  public ResponseEntity<List<DmRoomDto>> getAllRooms(@RequestParam UUID userId) {
+    return ResponseEntity.ok().body(dmRoomService.getAllRoomsForUser(userId));
+  }
+  @DeleteMapping("/{roomId}") // 유저가 속한 룸 삭제
+  public ResponseEntity<Void> deleteRoom(@PathVariable UUID roomId, @RequestParam UUID userId) {
+    dmRoomService.deleteRoom(userId, roomId);
+    return ResponseEntity.noContent().build();
+  }
+
+
+
+}

--- a/src/main/java/team03/mopl/domain/dm/controller/DmWebSocketController.java
+++ b/src/main/java/team03/mopl/domain/dm/controller/DmWebSocketController.java
@@ -1,0 +1,33 @@
+package team03.mopl.domain.dm.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import team03.mopl.domain.dm.dto.DmDto;
+import team03.mopl.domain.dm.dto.DmMessage;
+import team03.mopl.domain.dm.service.DmService;
+
+@Controller
+@RequiredArgsConstructor
+public class DmWebSocketController {
+
+  private final SimpMessagingTemplate messagingTemplate;
+  private final DmService dmService;
+
+  @MessageMapping("/dm.send") // /app/dm.send
+  public void sendMessage(DmMessage dmMessage) {
+    // 메시지를 DB에 저장
+    DmDto saved = dmService.sendDm(
+        dmMessage.getSenderId(),
+        dmMessage.getRoomId(),
+        dmMessage.getContent()
+    );
+
+    // 저장된 값을 그대로 broadcast
+    messagingTemplate.convertAndSend(
+        "/topic/dm.room." + dmMessage.getRoomId(),
+        saved
+    );
+  }
+}

--- a/src/main/java/team03/mopl/domain/dm/dto/DmDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmDto.java
@@ -1,0 +1,44 @@
+package team03.mopl.domain.dm.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import lombok.Getter;
+import team03.mopl.domain.dm.entity.Dm;
+
+@Getter
+public class DmDto {
+  private final UUID id;
+  private final UUID senderId;
+  private final String content;
+  private final List<UUID> readUserIds;  // ← 대문자 U
+  private final int unreadCount;
+  private final LocalDateTime createdAt;
+  private final UUID roomId;
+
+  @Builder
+  public DmDto(UUID id, UUID senderId, String content, List<UUID> readUserIds,
+      int unreadCount, LocalDateTime createdAt, UUID roomId) {
+    this.id = id;
+    this.senderId = senderId;
+    this.content = content;
+    this.readUserIds = readUserIds;
+    this.unreadCount = unreadCount;
+    this.createdAt = createdAt;
+    this.roomId = roomId;
+  }
+
+  public static DmDto from(Dm dm) {
+    return DmDto.builder()
+        .id(dm.getId())
+        .senderId(dm.getSenderId())
+        .content(dm.getContent())
+        .readUserIds(dm.getReadUserIds())
+        .unreadCount(dm.getUnreadCount())
+        .createdAt(dm.getCreatedAt())
+        .roomId(dm.getDmRoom().getId())
+        .build();
+  }
+}
+

--- a/src/main/java/team03/mopl/domain/dm/dto/DmMessage.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmMessage.java
@@ -1,0 +1,18 @@
+package team03.mopl.domain.dm.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DmMessage {
+  private UUID roomId;
+  private UUID senderId;
+  private String content;
+  private boolean isRead;
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import team03.mopl.domain.dm.entity.DmRoom;
 
 @Getter
 @NoArgsConstructor
@@ -21,7 +22,7 @@ public class DmRoomDto {
     this.createdAt = createdAt;
   }
 
-  public static DmRoomDto from(team03.mopl.domain.dm.entity.DmRoom room) {
+  public static DmRoomDto from(DmRoom room) {
     return new DmRoomDto(
         room.getId(),
         room.getSenderId(),

--- a/src/main/java/team03/mopl/domain/dm/entity/Dm.java
+++ b/src/main/java/team03/mopl/domain/dm/entity/Dm.java
@@ -1,6 +1,8 @@
 package team03.mopl.domain.dm.entity;
 
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -10,8 +12,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "dms")
@@ -28,27 +33,33 @@ public class Dm {
   @Column(name = "content", length = 255, nullable = false)
   private String content;
 
-  @Column(name = "is_read", nullable = false)
-  private boolean isRead = false;
+  /* @Column(name = "is_read", nullable = false)
+  private List<UUID> isRead = false;*/
+  @ElementCollection
+  @CollectionTable(name = "dm_read_users", joinColumns = @JoinColumn(name = "dm_id"))
+  @Column(name = "user_id")
+  private List<UUID> readUserIds = new ArrayList<>();
 
   @Column(name = "created_at", updatable = false, nullable = false)
   private LocalDateTime createdAt = LocalDateTime.now();
 
+  /*if (!dmRoom.getMessages().contains(this)) {
+      dmRoom.getMessages().add(this);
+    }*/
+  @Setter
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "dm_room_id", nullable = false)
   private DmRoom dmRoom;
 
-  public void setDmRoom(DmRoom dmRoom) {
-    this.dmRoom = dmRoom;
-
-    if (!dmRoom.getMessages().contains(this)) {
-      dmRoom.getMessages().add(this);
-    }
+  // 메시지를 읽은 사람은 리스트에 추가
+  public void readDm(UUID userId) {
+    readUserIds.add(userId);
   }
-
-  public void setRead(){
-    isRead = true;
+  // 2명 중 읽은 사람 수 만큼 빼기
+  public int getUnreadCount() {
+    return 2 - readUserIds.size();
   }
+  //public void setRead(){    isRead = true;  }
 
   protected Dm() {}
 

--- a/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
+++ b/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.dm.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,20 +13,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Table(name = "dm_rooms")
+@EntityListeners(AuditingEntityListener.class)
 public class DmRoom {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private UUID id;
 
+  @Setter
   @Column(name = "sender_id")
   private UUID senderId;
 
+  @Setter
   @Column(name = "receiver_id")
   private UUID receiverId;
 
@@ -42,11 +48,6 @@ public class DmRoom {
   public DmRoom(UUID senderId, UUID receiverId) {
     this.senderId = senderId;
     this.receiverId = receiverId;
-  }
-  // 도메인 메서드
-  public boolean setSenderId(UUID senderId) {
-    this.senderId = senderId;
-    return true;
   }
   public boolean nobodyInRoom() {
     if( senderId == null && receiverId == null ) {

--- a/src/main/java/team03/mopl/domain/dm/repository/DmRoomRepository.java
+++ b/src/main/java/team03/mopl/domain/dm/repository/DmRoomRepository.java
@@ -5,12 +5,13 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team03.mopl.domain.dm.entity.DmRoom;
 
 public interface DmRoomRepository extends JpaRepository<DmRoom, UUID> {
 
   @Query("SELECT r FROM DmRoom r WHERE (r.senderId = :user1 AND r.receiverId = :user2) OR (r.senderId = :user2 AND r.receiverId = :user1)")
-  Optional<DmRoom> findByRoomBetweenUsers(UUID userA, UUID userB);
+  Optional<DmRoom> findByRoomBetweenUsers(@Param("user1") UUID userA, @Param("user2") UUID userB);
 
   List<DmRoom> findBySenderIdOrReceiverId(UUID senderId, UUID receiverId);
 }

--- a/src/main/java/team03/mopl/domain/dm/service/DmRoomService.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmRoomService.java
@@ -2,20 +2,19 @@ package team03.mopl.domain.dm.service;
 
 import java.util.List;
 import java.util.UUID;
+import team03.mopl.domain.dm.dto.DmRoomDto;
 import team03.mopl.domain.dm.entity.DmRoom;
 
 public interface DmRoomService {
 
-  DmRoom createRoom(UUID senderId, UUID receiverId);
+  DmRoomDto createRoom(UUID senderId, UUID receiverId);
 
-  DmRoom getRoom(UUID roomId);
+  DmRoomDto getRoom(UUID roomId);
 
-  DmRoom findOrCreateRoom(UUID userA, UUID userB);
+  DmRoomDto findOrCreateRoom(UUID userA, UUID userB);
 
-  List<DmRoom> getAllRoomsForUser(UUID userId);
+  List<DmRoomDto> getAllRoomsForUser(UUID userId);
 
-  boolean existsBetween(UUID userA, UUID userB);
-
-  void deleteRoom(UUID roomId);
+  void deleteRoom(UUID userId, UUID roomId);
 
 }

--- a/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
@@ -2,9 +2,11 @@ package team03.mopl.domain.dm.service;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team03.mopl.domain.dm.dto.DmRoomDto;
 import team03.mopl.domain.dm.entity.Dm;
 import team03.mopl.domain.dm.entity.DmRoom;
 import team03.mopl.domain.dm.repository.DmRoomRepository;
@@ -18,45 +20,46 @@ public class DmRoomServiceImpl implements DmRoomService {
 
   @Override
   @Transactional
-  public DmRoom createRoom(UUID senderId, UUID receiverId) {
+  public DmRoomDto createRoom(UUID senderId, UUID receiverId) {
     //추후 유저 검증 필요
-    return dmRoomRepository.save(new DmRoom(senderId, receiverId));
+    return DmRoomDto.from(dmRoomRepository.save(new DmRoom(senderId, receiverId)));
   }
 
   @Override
-  public DmRoom getRoom(UUID roomId) {
-    return dmRoomRepository.findById(roomId).orElseThrow(()->new IllegalArgumentException("Room not found"));
+  public DmRoomDto getRoom(UUID roomId) {
+    return DmRoomDto.from(dmRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("Room not found")));
   }
 
   @Override
   @Transactional
-  public DmRoom findOrCreateRoom(UUID userA, UUID userB) {
-    return dmRoomRepository.findByRoomBetweenUsers(userA, userB).orElseGet(()->dmRoomRepository.save(createRoom(userA, userB)));
+  public DmRoomDto findOrCreateRoom(UUID userA, UUID userB) {
+    return dmRoomRepository.findByRoomBetweenUsers(userA, userB).map(DmRoomDto::from).orElseGet(() -> createRoom(userA, userB));
   }
 
   // 유저의 모든 채팅방
   @Override
-  public List<DmRoom> getAllRoomsForUser(UUID userId) {
-    return dmRoomRepository.findBySenderIdOrReceiverId(userId, userId);
+  public List<DmRoomDto> getAllRoomsForUser(UUID userId) {
+    return dmRoomRepository.findBySenderIdOrReceiverId(userId, userId).stream().map(DmRoomDto::from).collect(Collectors.toList());
   }
-
-  // 두 유저의 개인 채팅방 존재 여부
   @Override
-  public boolean existsBetween(UUID userA, UUID userB) {
-    return dmRoomRepository.findByRoomBetweenUsers(userA, userB).isPresent();
-  }
-
-  @Override
-  public void deleteRoom(UUID roomId) {
+  public void deleteRoom(UUID userId, UUID roomId) { //파라미터 변경! ( 삭제하고자 하는 룸의 유저가 삭제가능 )
     // 둘 다 나가기 전까지는 채팅이 살아있어야 함
     DmRoom dmRoom = dmRoomRepository.findById(roomId).orElseThrow(() -> new IllegalArgumentException("Room not found"));
-    dmRoom.setSenderId(null);
-    if( dmRoom.nobodyInRoom()){
-      List<Dm> messages = dmRoom.getMessages();
-      for (Dm message : messages) {
-        dmService.deleteDm(message.getId());
+    if( dmRoom.getReceiverId().equals(userId) || dmRoom.getSenderId().equals(userId)) {
+      //둘 중 하나의 유저가 나가고 싶어함
+      if (dmRoom.getSenderId().equals(userId)){
+        dmRoom.setSenderId(null);
+      }else {
+        dmRoom.setReceiverId(null);
       }
-      dmRoomRepository.delete(dmRoom);
+      //아무도 없는지 확인
+      if (dmRoom.nobodyInRoom()) {
+        List<Dm> messages = dmRoom.getMessages();
+        for (Dm message : messages) {
+          dmService.deleteDm(message.getId());
+        }
+        dmRoomRepository.delete(dmRoom);
+      }
     }
   }
 

--- a/src/main/java/team03/mopl/domain/dm/service/DmService.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmService.java
@@ -2,13 +2,14 @@ package team03.mopl.domain.dm.service;
 
 import java.util.List;
 import java.util.UUID;
+import team03.mopl.domain.dm.dto.DmDto;
 import team03.mopl.domain.dm.entity.Dm;
 
 public interface DmService {
 
-  Dm sendDm(UUID senderId, UUID roomId, String content);
+  DmDto sendDm(UUID senderId, UUID roomId, String content);
 
-  List<Dm> getDmList(UUID roomId);
+  List<DmDto> getDmList(UUID roomId, UUID userId);
 
   void readAll(UUID roomId, UUID userId);
 


### PR DESCRIPTION
## 🛰️ Issue Number

- #27 

## 🪐 작업 내용
1. 양방향 웹통신을 위한 의존성 추가
![image](https://github.com/user-attachments/assets/7e95a69b-8558-406c-8360-573b37cc200d)

2. dm 도메인 변경
1 대 1 통신에서 서로를 읽었다고 표시하기 위해서는 isRead boolean로는 구현로직이 떠오르지 않아서 
내부적으로 UUID를 가지는 리스트를 통해 해당 Dm을 읽은 UUID를 포함하도록 수정했습니다.

3. dmRoom 도메인 메서드 변경
@CreatedDate를 위한 @EntityListeners(AuditingEntityListener.class) 추가
senderId, receiverId 에 @Setter 추가

4. 테스트 로직과 예외 로직 추가 못했습니다. 

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?