### PR TITLE
feat: 알림 구현 및 DM, 팔로우 도메인에 알림 로직 추가 그리고 에러 처리

### DIFF
--- a/src/main/java/team03/mopl/common/exception/ErrorCode.java
+++ b/src/main/java/team03/mopl/common/exception/ErrorCode.java
@@ -15,7 +15,17 @@ public enum ErrorCode {
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_001", "존재하지 않는 리뷰입니다."),
 
   CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM_001", "존재하지 않는 채팅방입니다."),
-  ALREADY_JOINED_CHATROOM(HttpStatus.CREATED, "CHATROOM_002", "이미 참여중인 채팅방입니다.");
+  ALREADY_JOINED_CHATROOM(HttpStatus.CREATED, "CHATROOM_002", "이미 참여중인 채팅방입니다."),
+  //DM
+  DM_NOT_FOUND(HttpStatus.NOT_FOUND, "DM_001", "존재하지 않는 다이렉트 메시지입니다."),
+  DM_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "DM_001", "존재하지 않는 채팅방입니다."),
+  //Follow
+  FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW_001", "존재하지 않는 팔로우입니다."),
+  ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW_002", "이미 팔로우하고 있습니다."),
+  CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "FOLLOW_003", "자기 자신을 팔로우하고 있습니다."),
+  //Notification
+  NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "존재하지 않는 알림입니다.");
+
 
   private HttpStatus status;
   // 추적하기 쉽도록하는 필드

--- a/src/main/java/team03/mopl/common/exception/dm/DmException.java
+++ b/src/main/java/team03/mopl/common/exception/dm/DmException.java
@@ -1,0 +1,20 @@
+package team03.mopl.common.exception.dm;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+import team03.mopl.common.exception.MoplException;
+
+public class DmException extends MoplException {
+
+  public DmException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public DmException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public DmException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/dm/DmNotFoundException.java
+++ b/src/main/java/team03/mopl/common/exception/dm/DmNotFoundException.java
@@ -1,0 +1,18 @@
+package team03.mopl.common.exception.dm;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class DmNotFoundException extends DmException {
+  public DmNotFoundException() {
+    super(ErrorCode.DM_NOT_FOUND);
+  }
+
+  public DmNotFoundException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public DmNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/dm/DmRoomException.java
+++ b/src/main/java/team03/mopl/common/exception/dm/DmRoomException.java
@@ -1,0 +1,20 @@
+package team03.mopl.common.exception.dm;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+import team03.mopl.common.exception.MoplException;
+
+public class DmRoomException extends MoplException {
+
+  public DmRoomException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public DmRoomException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public DmRoomException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/dm/DmRoomNotFoundException.java
+++ b/src/main/java/team03/mopl/common/exception/dm/DmRoomNotFoundException.java
@@ -1,0 +1,18 @@
+package team03.mopl.common.exception.dm;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class DmRoomNotFoundException extends DmException {
+  public DmRoomNotFoundException() {
+    super(ErrorCode.DM_ROOM_NOT_FOUND);
+  }
+
+  public DmRoomNotFoundException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public DmRoomNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/follow/AlreadyFollowingException.java
+++ b/src/main/java/team03/mopl/common/exception/follow/AlreadyFollowingException.java
@@ -1,0 +1,20 @@
+package team03.mopl.common.exception.follow;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class AlreadyFollowingException extends FollowException {
+
+  public AlreadyFollowingException() {
+    super(ErrorCode.ALREADY_FOLLOWING);
+  }
+
+  public AlreadyFollowingException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public AlreadyFollowingException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/follow/CantFollowSelfException.java
+++ b/src/main/java/team03/mopl/common/exception/follow/CantFollowSelfException.java
@@ -1,0 +1,20 @@
+package team03.mopl.common.exception.follow;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class CantFollowSelfException extends FollowException {
+
+  public CantFollowSelfException() {
+    super(ErrorCode.CANNOT_FOLLOW_SELF);
+  }
+
+  public CantFollowSelfException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public CantFollowSelfException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/follow/FollowException.java
+++ b/src/main/java/team03/mopl/common/exception/follow/FollowException.java
@@ -1,0 +1,19 @@
+package team03.mopl.common.exception.follow;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+import team03.mopl.common.exception.MoplException;
+
+public class FollowException extends MoplException {
+  public FollowException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public FollowException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public FollowException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/follow/FollowNotFoundException.java
+++ b/src/main/java/team03/mopl/common/exception/follow/FollowNotFoundException.java
@@ -1,0 +1,20 @@
+package team03.mopl.common.exception.follow;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class FollowNotFoundException extends FollowException {
+
+  public FollowNotFoundException() {
+    super(ErrorCode.FOLLOW_NOT_FOUND);
+  }
+
+  public FollowNotFoundException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public FollowNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/notification/NotificationException.java
+++ b/src/main/java/team03/mopl/common/exception/notification/NotificationException.java
@@ -1,0 +1,19 @@
+package team03.mopl.common.exception.notification;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+import team03.mopl.common.exception.MoplException;
+
+public class NotificationException extends MoplException {
+  public NotificationException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public NotificationException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public NotificationException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/notification/NotificationNotFoundException.java
+++ b/src/main/java/team03/mopl/common/exception/notification/NotificationNotFoundException.java
@@ -1,0 +1,21 @@
+package team03.mopl.common.exception.notification;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+import team03.mopl.common.exception.review.ReviewException;
+
+public class NotificationNotFoundException extends ReviewException {
+
+  public NotificationNotFoundException() {
+    super(ErrorCode.NOTIFICATION_NOT_FOUND);
+  }
+
+  public NotificationNotFoundException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public NotificationNotFoundException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+
+  }
+}

--- a/src/main/java/team03/mopl/domain/dm/dto/DmDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmDto.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.dm.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,13 +13,13 @@ public class DmDto {
   private final UUID id;
   private final UUID senderId;
   private final String content;
-  private final List<UUID> readUserIds;  // ← 대문자 U
+  private final Set<UUID> readUserIds;
   private final int unreadCount;
   private final LocalDateTime createdAt;
   private final UUID roomId;
 
   @Builder
-  public DmDto(UUID id, UUID senderId, String content, List<UUID> readUserIds,
+  public DmDto(UUID id, UUID senderId, String content, Set<UUID> readUserIds,
       int unreadCount, LocalDateTime createdAt, UUID roomId) {
     this.id = id;
     this.senderId = senderId;

--- a/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
@@ -14,6 +14,8 @@ public class DmRoomDto {
   private UUID senderId;
   private UUID receiverId;
   private LocalDateTime createdAt;
+  private String lastMessage;
+  private long newMessageCount;
 
   public DmRoomDto(UUID id, UUID senderId, UUID receiverId, LocalDateTime createdAt) {
     this.id = id;
@@ -21,6 +23,27 @@ public class DmRoomDto {
     this.receiverId = receiverId;
     this.createdAt = createdAt;
   }
+
+  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, LocalDateTime createdAt, String lastMessage, long newMessageCount) {
+    this.id = id;
+    this.senderId = senderId;
+    this.receiverId = receiverId;
+    this.createdAt = createdAt;
+    this.lastMessage = lastMessage;
+    this.newMessageCount = newMessageCount;
+  }
+
+  public static DmRoomDto from(String lastMessage, int unreadCount, DmRoom room) {
+    return new DmRoomDto(
+        room.getId(),
+        room.getSenderId(),
+        room.getReceiverId(),
+        room.getCreatedAt(),
+        lastMessage,
+        unreadCount
+    );
+  }
+
 
   public static DmRoomDto from(DmRoom room) {
     return new DmRoomDto(

--- a/src/main/java/team03/mopl/domain/follow/controller/FollowController.java
+++ b/src/main/java/team03/mopl/domain/follow/controller/FollowController.java
@@ -1,0 +1,61 @@
+package team03.mopl.domain.follow.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team03.mopl.domain.follow.service.FollowService;
+import team03.mopl.domain.user.UserResponse;
+
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+public class FollowController {
+
+  private final FollowService followService;
+
+  // 팔로우하기
+  @PostMapping("/{followerId}/follow/{followingId}")
+  public ResponseEntity<Void> follow(@PathVariable UUID followerId, @PathVariable UUID followingId) {
+    followService.follow(followerId, followingId);
+    return ResponseEntity.ok().build();
+  }
+  @DeleteMapping("/{followerId}/unfollow/{followingId}")
+  public ResponseEntity<Void> unfollow(
+      @PathVariable UUID followerId,
+      @PathVariable UUID followingId
+  ) {
+    followService.unfollow(followerId, followingId);
+    return ResponseEntity.ok().build();
+  }
+  // 팔로잉 목록
+  @GetMapping("/{userId}/following")
+  public ResponseEntity<List<UserResponse>> getFollowing(
+      @PathVariable UUID userId
+  ) {
+    return ResponseEntity.ok(followService.getFollowing(userId));
+  }
+
+  // 팔로워 목록
+  @GetMapping("/{userId}/followers")
+  public ResponseEntity<List<UserResponse>> getFollowers(
+      @PathVariable UUID userId
+  ) {
+    return ResponseEntity.ok(followService.getFollowers(userId));
+  }
+
+  // 팔로우 여부 확인
+  @GetMapping("/{followerId}/is-following/{followingId}")
+  public ResponseEntity<Boolean> isFollowing(
+      @PathVariable UUID followerId,
+      @PathVariable UUID followingId
+  ) {
+    return ResponseEntity.ok(followService.isFollowing(followerId, followingId));
+  }
+}

--- a/src/main/java/team03/mopl/domain/follow/service/FollowService.java
+++ b/src/main/java/team03/mopl/domain/follow/service/FollowService.java
@@ -2,12 +2,13 @@ package team03.mopl.domain.follow.service;
 
 import java.util.List;
 import java.util.UUID;
+import team03.mopl.domain.user.UserResponse;
 
 public interface FollowService {
   void follow(UUID followerId, UUID followingId);
   void unfollow(UUID followerId, UUID followingId);
-  List<UUID> getFollowing(UUID userId);   // 내가 팔로우한 사람 목록
-  List<UUID> getFollowers(UUID userId);   // 나를 팔로우한 사람 목록
+  List<UserResponse> getFollowing(UUID userId);   // 내가 팔로우한 사람 목록
+  List<UserResponse> getFollowers(UUID userId);   // 나를 팔로우한 사람 목록
   boolean isFollowing(UUID followerId, UUID followingId);
 }
 

--- a/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
@@ -4,52 +4,71 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import team03.mopl.common.exception.follow.AlreadyFollowingException;
+import team03.mopl.common.exception.follow.CantFollowSelfException;
+import team03.mopl.common.exception.follow.FollowNotFoundException;
+import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.follow.entity.Follow;
 import team03.mopl.domain.follow.repository.FollowRepository;
+import team03.mopl.domain.notification.entity.NotificationType;
+import team03.mopl.domain.notification.service.NotificationService;
 import team03.mopl.domain.user.UserRepository;
 import team03.mopl.domain.user.User;
+import team03.mopl.domain.user.UserResponse;
+import team03.mopl.domain.user.UserService;
 
 @Service
 @RequiredArgsConstructor
 public class FollowServiceImpl implements FollowService {
   private final FollowRepository followRepository;
   private final UserRepository userRepository;
+  private final UserService userService;
+  private final NotificationService notificationService;
 
   @Override
   public void follow(UUID followerId, UUID followingId) {
-    User follower = userRepository.findById(followerId).orElseThrow();
-    User following = userRepository.findById(followingId).orElseThrow();
+    //팔로우 하는 사람
+    User follower = userRepository.findById(followerId).orElseThrow(UserNotFoundException::new);
+    //팔로우 당하는 사람
+    User following = userRepository.findById(followingId).orElseThrow(UserNotFoundException::new);
     if( !followingId.equals(followerId) ) {
-      throw new IllegalArgumentException(); //자신을 팔로잉할 수 없음
+      throw new CantFollowSelfException(); //자신을 팔로잉할 수 없음
     }
     boolean alreadyFollowing = followRepository.existsByFollowerIdAndFollowingId(followerId, followingId);
     if( alreadyFollowing ) {
-      throw new IllegalArgumentException(); //이미 팔로잉 중
+      throw new AlreadyFollowingException(); //이미 팔로잉 중
     }
     Follow follow = new Follow(followerId, followingId);
+
+    // 알림 전송 추가
+    notificationService.sendNotification(following.getId(), NotificationType.FOLLOWED, following.getName()+"이(가) 팔로우 했습니다.");
+
     followRepository.save(follow);
   }
 
   @Override
   public void unfollow(UUID followerId, UUID followingId) {
-    User follower = userRepository.findById(followerId).orElseThrow();
-    User following = userRepository.findById(followingId).orElseThrow();
+    User unFollower = userRepository.findById(followerId).orElseThrow(FollowNotFoundException::new);
+    User unFollowing = userRepository.findById(followingId).orElseThrow(FollowNotFoundException::new);
+
+    // 알림 전송 추가
+    notificationService.sendNotification(unFollowing.getId(), NotificationType.UNFOLLOWED, unFollowing.getName()+"이(가) 언팔로우 했습니다.");
+
     followRepository.deleteByFollowerIdAndFollowingId(followerId, followingId);
   }
-  /*
-  * 
-  * UserDto 받고나서 반환 값 List<UUID> -> List<UserDto> 로 수정하기
-  * 
-  * */
+
   //나의 팔로잉 목록
   @Override
-  public List<UUID> getFollowing(UUID userId) {
-    return followRepository.findAllByFollowerId(userId).stream().map(Follow::getFollowingId).toList();
+  public List<UserResponse> getFollowing(UUID userId) {
+    List<UUID> list = followRepository.findAllByFollowerId(userId).stream().map(Follow::getFollowingId).toList();
+    return list.stream().map(userService::find).toList();
   }
+
   //나를 팔로우하는 사람들 목록
   @Override
-  public List<UUID> getFollowers(UUID userId) {
-    return followRepository.findAllByFollowingId(userId).stream().map(Follow::getFollowerId).toList();
+  public List<UserResponse> getFollowers(UUID userId) {
+    List<UUID> list = followRepository.findAllByFollowingId(userId).stream().map(Follow::getFollowerId).toList();
+    return list.stream().map(userService::find).toList();
   }
 
   @Override

--- a/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
@@ -1,0 +1,47 @@
+package team03.mopl.domain.notification.controller;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team03.mopl.domain.notification.dto.NotificationDto;
+import team03.mopl.domain.notification.service.NotificationService;
+import team03.mopl.domain.notification.service.SseEmitterManager;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+  private final SseEmitterManager sseEmitterManager;
+
+  /**
+   * SSE 구독 연결
+   * ResponseEntity나 JSON을 반환하면 SSE 프로토콜이 성립하지 않아서 EventSource나 SSE 클라이언트가 아예 수신을 못 합니다.
+   */
+  @GetMapping("/subscribe/{userId}")
+  public SseEmitter subscribe(@PathVariable UUID userId) {
+    return sseEmitterManager.subscribe(userId);
+  }
+
+  /**
+   * 알림 내역 조회
+   */
+  @GetMapping("/{userId}")
+  public ResponseEntity<List<NotificationDto>> getNotifications(@PathVariable UUID userId) {
+    List<NotificationDto> list = notificationService.getNotifications(userId).stream().map(NotificationDto::from).toList();
+
+    //알림 내역을 조회했다는 건 읽었다는 것
+    notificationService.markAllAsRead(userId);
+
+    return ResponseEntity.ok(list);
+  }
+
+
+}

--- a/src/main/java/team03/mopl/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/team03/mopl/domain/notification/dto/NotificationDto.java
@@ -1,0 +1,32 @@
+package team03.mopl.domain.notification.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import team03.mopl.domain.notification.entity.Notification;
+import team03.mopl.domain.notification.entity.NotificationType;
+
+@Data
+@RequiredArgsConstructor
+public class NotificationDto {
+
+  private final UUID id;
+  private final String content;
+  private final NotificationType notificationType;
+  private final LocalDateTime createdAt;
+
+  public NotificationDto(String content, NotificationType notificationType, LocalDateTime createdAt) {
+    this.id = null;
+    this.content = content;
+    this.notificationType = notificationType;
+    this.createdAt = createdAt;
+  }
+
+  public static NotificationDto from(String content, NotificationType notificationType, LocalDateTime createdAt) {
+    return new NotificationDto(content, notificationType, createdAt);
+  }
+  public static NotificationDto from(Notification notification) {
+    return new NotificationDto(notification.getContent(), notification.getType(), notification.getCreatedAt());
+  }
+}

--- a/src/main/java/team03/mopl/domain/notification/entity/Notification.java
+++ b/src/main/java/team03/mopl/domain/notification/entity/Notification.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.notification.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -10,10 +11,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "notifications")
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Notification {
 
   @Id
@@ -37,4 +44,12 @@ public class Notification {
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  public Notification(UUID receiverId, NotificationType type, String content) {
+    this.receiverId = receiverId;
+    this.type = type;
+    this.content = content;
+  }
+  public void setIsRead() {
+    this.isRead = true;
+  }
 }

--- a/src/main/java/team03/mopl/domain/notification/entity/NotificationType.java
+++ b/src/main/java/team03/mopl/domain/notification/entity/NotificationType.java
@@ -1,9 +1,21 @@
 package team03.mopl.domain.notification.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum NotificationType {
-  ROLE_CHANGED,              // 권한 변경
-  PLAYLIST_SUBSCRIBED,       // 내 재생목록을 구독
-  FOLLOWING_POSTED_PLAYLIST, // 팔로우한 사용자가 재생목록 등록
-  FOLLOWED,                  // 다른 사용자가 나를 팔로우
-  DM_RECEIVED;               // DM 수신
+  ROLE_CHANGED("role_changed"),
+  PLAYLIST_SUBSCRIBED("play_subscribed"),
+  FOLLOWING_POSTED_PLAYLIST("following_posted_playlist"),
+  FOLLOWED("followed"),
+  UNFOLLOWED("unfollowed"),
+  DM_RECEIVED("dm_received"),
+  NEW_DM_ROOM("created new DM room");
+
+  private final String eventName;
+
+  NotificationType(String eventName) {
+    this.eventName = eventName;
+  }
+
 }

--- a/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package team03.mopl.domain.notification.repository;
+
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import team03.mopl.domain.notification.entity.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+  List<Notification> findByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
+
+  List<Notification> findByReceiverIdAndRead(UUID receiverId, boolean read);
+}

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
@@ -1,0 +1,13 @@
+package team03.mopl.domain.notification.service;
+
+import java.util.List;
+import java.util.UUID;
+import team03.mopl.domain.notification.entity.Notification;
+import team03.mopl.domain.notification.entity.NotificationType;
+
+public interface NotificationService {
+  void sendNotification(UUID receiverId, NotificationType type, String content);
+  List<Notification> getNotifications(UUID receiverId);
+  void markAllAsRead(UUID notificationId);
+}
+

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,36 @@
+package team03.mopl.domain.notification.service;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import team03.mopl.domain.notification.entity.Notification;
+import team03.mopl.domain.notification.entity.NotificationType;
+import team03.mopl.domain.notification.repository.NotificationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService{
+  private final NotificationRepository notificationRepository;
+  private final SseEmitterManager sseEmitterManager;
+
+  @Override
+  public void sendNotification(UUID receiverId, NotificationType type, String content) {
+    Notification notification = new Notification(receiverId, type, content);
+    Notification save = notificationRepository.save(notification);
+    sseEmitterManager.sendNotification(receiverId, save);
+  }
+
+  @Override
+  public List<Notification> getNotifications(UUID receiverId) {
+    return notificationRepository.findByReceiverIdOrderByCreatedAtDesc(receiverId);
+  }
+
+  @Override
+  public void markAllAsRead(UUID receiverId) {
+    List<Notification> unread = notificationRepository.findByReceiverIdAndRead(receiverId, false);
+    unread.forEach(Notification::setIsRead);
+    notificationRepository.saveAll(unread);
+  }
+
+}

--- a/src/main/java/team03/mopl/domain/notification/service/SseEmitterManager.java
+++ b/src/main/java/team03/mopl/domain/notification/service/SseEmitterManager.java
@@ -1,0 +1,82 @@
+package team03.mopl.domain.notification.service;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import team03.mopl.domain.notification.dto.NotificationDto;
+import team03.mopl.domain.notification.entity.Notification;
+
+@Service
+@RequiredArgsConstructor
+public class SseEmitterManager {
+  //추후 에러 로깅 필요
+  private final Map<UUID, SseEmitter> userConnections = new ConcurrentHashMap<>();
+
+  /*
+  * 클라이언트 쪽에서 N분마다 SSE연결을 재연결해줘야 한다.
+  * */
+  public SseEmitter subscribe(UUID userId) {
+    //기존에 연결된 sse가 있다면 연결 종료
+    SseEmitter sseEmitter = userConnections.get(userId);
+    if (sseEmitter != null) {
+      sseEmitter.complete();
+    }
+    SseEmitter emitter = new SseEmitter(10 * 60 * 1000L); //10분?
+    userConnections.put(userId, emitter);
+    //오류 발생 시 제거
+    emitter.onCompletion(() -> userConnections.remove(userId));
+    emitter.onTimeout(() -> userConnections.remove(userId));
+    emitter.onError((e) -> userConnections.remove(userId));
+
+    try {
+      // 연결 성공 알림
+      emitter.send(SseEmitter.event()
+          .name("connected")
+          .data("알림 서비스에 연결되었습니다."));
+
+    } catch (IOException e) {
+      // 전송 중 예외 발생시 연결 제거 및 종료 처리
+      userConnections.remove(userId);
+      emitter.completeWithError(e);
+    }
+    return emitter;
+  }
+
+  // 특정 사용자에게 알림 전송
+  public void sendNotification(UUID userId, Notification notification) {
+    SseEmitter emitter = userConnections.get(userId); // 사용자 연결 확인
+
+    if (emitter != null) {
+      try {
+        String eventName = notification.getType().getEventName();
+        emitter.send(SseEmitter.event()
+            .name(eventName) // 이벤트 이름
+            .id(String.valueOf(notification.getId())) // 고유 이벤트 ID ( String만 허용 )
+            .data(NotificationDto.from(notification))); // 알림 데이터 전송
+
+        System.out.println("알림 전송 성공: " + userId + " - " + notification.getContent()); //getType() 가 나을수도?
+
+      } catch (IOException e) {
+        System.out.println("알림 전송 실패: " + userId);
+        userConnections.remove(userId);
+      }
+    } else {
+      // 연결 상태가 아닐 경우
+      System.out.println("사용자 " + userId + "가 연결되어 있지 않음");
+    }
+  }
+
+  // 현재 온라인 사용자 수
+  public int getOnlineUserCount() {
+    return userConnections.size();
+  }
+
+  // 특정 사용자 온라인 여부
+  public boolean isUserOnline(UUID userId) {
+    return userConnections.containsKey(userId);
+  }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

- #44 

## 🪐 작업 내용
- 알림 로직 추가
- DM, 팔로우 도메인에 알림 로직 추가
- 알림, DM, 팔로우 도메인 에러 처리

로그인 해서 서로 DM 주고 받고 DM 올 떄마다 알림 생성하는 것까지 확인했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?