### PR TITLE
feat: 실시간 시청방 내 채팅 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,9 @@ dependencies {
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     //websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    testImplementation 'org.springframework:spring-websocket'
+    testImplementation 'org.springframework:spring-messaging'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/team03/mopl/common/config/WebSocketConfig.java
+++ b/src/main/java/team03/mopl/common/config/WebSocketConfig.java
@@ -1,4 +1,4 @@
-package team03.mopl.domain.dm.config;
+package team03.mopl.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;

--- a/src/main/java/team03/mopl/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/team03/mopl/domain/chat/controller/ChatMessageController.java
@@ -1,0 +1,44 @@
+package team03.mopl.domain.chat.controller;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import team03.mopl.domain.chat.dto.ChatMessageCreateRequest;
+import team03.mopl.domain.chat.dto.ChatMessageDto;
+import team03.mopl.domain.chat.dto.SystemMessageDto;
+import team03.mopl.domain.chat.service.ChatMessageService;
+import team03.mopl.domain.chat.service.ChatRoomService;
+import team03.mopl.jwt.CustomUserDetails;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+  private final ChatRoomService chatRoomService;
+  private final ChatMessageService chatMessageService;
+
+  @MessageMapping("/rooms/{roomId}/send")
+  @SendTo("/topic/rooms/{roomId}")
+  public ChatMessageDto sendMessage(@DestinationVariable UUID roomId,
+      ChatMessageCreateRequest request) {
+    if (!request.chatRoomId().equals(roomId)) {
+      //본문의 ChatRoom id와 url의 id가 같은지 한번 더 검증함
+      throw new IllegalArgumentException("Room ID가 일치하지 않습니다.");
+    }
+    return chatMessageService.create(request);
+  }
+
+  @MessageMapping("/chat/room/{roomId}/join")
+  @SendTo("/topic/room/{roomId}")
+  public SystemMessageDto joinRoom(@DestinationVariable UUID roomId, @AuthenticationPrincipal
+  CustomUserDetails userDetails) {
+
+    chatRoomService.join(roomId, userDetails.getId());
+
+    return new SystemMessageDto("ENTER", userDetails.getUsername() + "님이 참여하셨습니다.");
+  }
+}

--- a/src/main/java/team03/mopl/domain/chat/controller/ChatRoomController.java
+++ b/src/main/java/team03/mopl/domain/chat/controller/ChatRoomController.java
@@ -29,7 +29,7 @@ public class ChatRoomController {
   }
 
   @GetMapping("/{roomId}")
-  public ResponseEntity<ChatRoomDto> getChatRoom(@PathVariable String roomId) {
+  public ResponseEntity<ChatRoomDto> getChatRoom(@PathVariable("roomId") String roomId) {
     return ResponseEntity.ok(chatRoomService.getById(UUID.fromString(roomId)));
   }
 

--- a/src/main/java/team03/mopl/domain/chat/dto/SystemMessageDto.java
+++ b/src/main/java/team03/mopl/domain/chat/dto/SystemMessageDto.java
@@ -1,0 +1,10 @@
+package team03.mopl.domain.chat.dto;
+
+//소켓 연결 및 채팅방 입장 성공 이벤트를 전달하기 위한 메세지 Dto
+public record SystemMessageDto(
+    //입장 시 알림 이외의 시스템 메시지 추가되면 Enum으로 리팩터링 필요
+    String type,
+    String message
+) {
+
+}

--- a/src/test/java/team03/mopl/common/config/TestSecurityConfig.java
+++ b/src/test/java/team03/mopl/common/config/TestSecurityConfig.java
@@ -1,0 +1,34 @@
+package team03.mopl.common.config;
+
+import java.util.Collections;
+import java.util.UUID;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import team03.mopl.domain.user.User;
+import team03.mopl.jwt.CustomUserDetails;
+
+//테스트용 보안 설정
+@TestConfiguration
+@EnableWebSecurity
+public class TestSecurityConfig {
+
+  @Bean
+  public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .securityMatcher("/ws/**")
+        .authorizeHttpRequests(authz -> authz.anyRequest().permitAll())
+        .csrf(csrf -> csrf.disable());
+    return http.build();
+  }
+}

--- a/src/test/java/team03/mopl/domain/chat/controller/ChatMessageControllerTest.java
+++ b/src/test/java/team03/mopl/domain/chat/controller/ChatMessageControllerTest.java
@@ -1,0 +1,112 @@
+package team03.mopl.domain.chat.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team03.mopl.domain.chat.dto.ChatMessageCreateRequest;
+import team03.mopl.domain.chat.dto.ChatMessageDto;
+import team03.mopl.domain.chat.dto.SystemMessageDto;
+import team03.mopl.domain.chat.service.ChatMessageService;
+import team03.mopl.domain.chat.service.ChatRoomService;
+import team03.mopl.jwt.CustomUserDetails;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageControllerTest {
+  //웹소켓 컨트롤러 단위 테스트
+  //todo
+  // 웹소켓 컨트롤러는 통합테스트로 실제 STOMP 클라이언트로 테스트하는 것도 추가해야함
+
+  @Mock
+  private ChatMessageService chatMessageService;
+
+  @Mock
+  private ChatRoomService chatRoomService;
+
+  @InjectMocks
+  private ChatMessageController chatMessageController;
+
+  @Nested
+  @DisplayName("채팅방 메세지 전송 요청")
+  class sendMessage {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      UUID mockRoomId = UUID.randomUUID();
+      UUID mockUserId = UUID.randomUUID();
+      String content = "테스트 메세지입니다.";
+
+      ChatMessageCreateRequest request = new ChatMessageCreateRequest(
+          mockRoomId,
+          mockUserId,
+          content,
+          LocalDateTime.now()
+      );
+      //when & then
+      ChatMessageDto chatMessageDto = chatMessageController.sendMessage(mockRoomId, request);
+
+      verify(chatMessageService).create(request);
+    }
+
+    @Test
+    @DisplayName("요청 파라미터로 주어진 채팅방 id와 메세지 생성 요청 바디의 채팅방Id가 일치하지 않음")
+    void fail() {
+      //given
+      UUID mockRoomId = UUID.randomUUID();
+      UUID mockUserId = UUID.randomUUID();
+      String content = "테스트 메세지입니다.";
+
+      ChatMessageCreateRequest request = new ChatMessageCreateRequest(
+          UUID.randomUUID(),
+          mockUserId,
+          content,
+          LocalDateTime.now()
+      );
+      //when & then
+      assertThrows(IllegalArgumentException.class,
+          () -> chatMessageController.sendMessage(mockRoomId, request));
+
+    }
+
+  }
+
+  @Nested
+  @DisplayName("채팅방 입장 요청")
+  class join {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      UUID mockRoomId = UUID.randomUUID();
+      UUID mockUserId = UUID.randomUUID();
+      String mockUserName = "테스트 사용자 이름";
+
+      CustomUserDetails mockUser = mock(CustomUserDetails.class);
+      when(mockUser.getId()).thenReturn(mockUserId);
+      when(mockUser.getUsername()).thenReturn(mockUserName);
+
+      //when
+      SystemMessageDto systemMessageDto = chatMessageController.joinRoom(mockRoomId, mockUser);
+
+      //then
+      verify(chatRoomService).join(mockRoomId, mockUserId);
+
+      assertEquals("ENTER", systemMessageDto.type());
+      assertEquals(mockUserName + "님이 참여하셨습니다.", systemMessageDto.message());
+    }
+  }
+}

--- a/src/test/java/team03/mopl/domain/chat/controller/ChatMessageControllerWebSocketTest.java
+++ b/src/test/java/team03/mopl/domain/chat/controller/ChatMessageControllerWebSocketTest.java
@@ -1,0 +1,113 @@
+package team03.mopl.domain.chat.controller;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+import team03.mopl.common.config.TestSecurityConfig;
+import team03.mopl.domain.chat.dto.ChatMessageDto;
+import team03.mopl.domain.chat.handler.ChatMessageFrameHandler;
+import team03.mopl.domain.chat.handler.TestStompSessionHandler;
+import team03.mopl.domain.chat.service.ChatMessageService;
+import team03.mopl.domain.chat.service.ChatRoomService;
+import team03.mopl.domain.curation.service.CurationService;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+@ActiveProfiles("test")
+@Import(TestSecurityConfig.class)
+class ChatMessageControllerWebSocketTest {
+
+  @LocalServerPort
+  private int port;
+
+  @MockitoBean
+  private ChatRoomService chatRoomService;
+
+  @MockitoBean
+  private ChatMessageService chatMessageService;
+
+  //StanfordCoreNLP 엔진을 초기화할 때 대규모 리소스를 적재함 -> OOM 발생
+  //curationService Mock 처리하여 init실행하지 않도록 설정
+  @MockitoBean
+  private CurationService curationService;
+
+
+  private StompSession stompSession;
+  private WebSocketStompClient stompClient;
+  private final BlockingQueue<ChatMessageDto> messageQueue = new ArrayBlockingQueue<>(10);
+
+  @BeforeEach
+  void setup() throws Exception {
+    // WebSocket 클라이언트 설정만
+    List<Transport> transports = List.of(
+        new WebSocketTransport(new StandardWebSocketClient())
+    );
+    SockJsClient sockJsClient = new SockJsClient(transports);
+
+    stompClient = new WebSocketStompClient(sockJsClient);
+    stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+    ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+    taskScheduler.afterPropertiesSet();
+    stompClient.setTaskScheduler(taskScheduler);
+
+    // 연결
+    CompletableFuture<StompSession> future = stompClient.connectAsync(
+        URI.create("ws://localhost:" + port + "/ws"),
+        null,
+        new StompHeaders(),
+        new TestStompSessionHandler()
+    );
+
+    stompSession = future.get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testWebSocketConnection() {
+    assertThat(stompSession.isConnected()).isTrue();
+  }
+
+  @Test
+  void testWebSocketEndpointExists() throws Exception {
+    // 엔드포인트 존재 확인
+    StompSession.Subscription subscription = stompSession.subscribe(
+        "/topic/rooms/" + UUID.randomUUID(),
+        new ChatMessageFrameHandler(messageQueue)
+    );
+
+    assertThat(subscription).isNotNull();
+    subscription.unsubscribe();
+  }
+
+  @AfterEach
+  void cleanup() {
+    if (stompSession != null && stompSession.isConnected()) {
+      stompSession.disconnect();
+    }
+  }
+}

--- a/src/test/java/team03/mopl/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/team03/mopl/domain/chat/controller/ChatRoomControllerTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientWebSecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
@@ -30,7 +33,11 @@ import team03.mopl.domain.chat.exception.ChatRoomNotFoundException;
 import team03.mopl.domain.chat.service.ChatRoomService;
 
 @WebMvcTest(controllers = ChatRoomController.class,
-    excludeAutoConfiguration = {SecurityAutoConfiguration.class})
+    excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class,
+        OAuth2ClientAutoConfiguration.class,
+        OAuth2ClientWebSecurityAutoConfiguration.class,
+        OAuth2ResourceServerAutoConfiguration.class})
 @DisplayName("채팅방 기능 컨트롤러 단위 테스트")
 class ChatRoomControllerTest {
 

--- a/src/test/java/team03/mopl/domain/chat/handler/ChatMessageFrameHandler.java
+++ b/src/test/java/team03/mopl/domain/chat/handler/ChatMessageFrameHandler.java
@@ -1,0 +1,30 @@
+package team03.mopl.domain.chat.handler;
+
+import java.util.concurrent.BlockingQueue;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import team03.mopl.domain.chat.dto.ChatMessageDto;
+import java.lang.reflect.Type;
+
+//채팅 메세지용 STOMP Frame Handler
+public class ChatMessageFrameHandler implements StompFrameHandler {
+
+  private final BlockingQueue<ChatMessageDto> messageQueue;
+
+  public ChatMessageFrameHandler(BlockingQueue<ChatMessageDto> messageQueue) {
+    this.messageQueue = messageQueue;
+  }
+
+  @Override
+  public Type getPayloadType(StompHeaders headers) {
+    return ChatMessageDto.class;
+  }
+
+  @Override
+  public void handleFrame(StompHeaders headers, Object payload) {
+    if (payload instanceof ChatMessageDto chatMessage) {
+      messageQueue.offer(chatMessage);
+      System.out.println("Received chat message: " + chatMessage.content());
+    }
+  }
+}

--- a/src/test/java/team03/mopl/domain/chat/handler/TestStompSessionHandler.java
+++ b/src/test/java/team03/mopl/domain/chat/handler/TestStompSessionHandler.java
@@ -1,0 +1,43 @@
+package team03.mopl.domain.chat.handler;
+
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+
+//테스트용 stomp 세션 handler
+public class TestStompSessionHandler extends StompSessionHandlerAdapter {
+
+  private final String sessionName;
+
+  public TestStompSessionHandler() {
+    this("default");
+  }
+
+  public TestStompSessionHandler(String sessionName) {
+    this.sessionName = sessionName;
+  }
+
+  @Override
+  public void afterConnected(StompSession session, StompHeaders connectedHeaders) {
+    System.out.println("[" + sessionName + "] Connected to WebSocket: " + session.getSessionId());
+    System.out.println("[" + sessionName + "] Connected headers: " + connectedHeaders);
+  }
+
+  @Override
+  public void handleException(StompSession session, StompCommand command,
+      StompHeaders headers, byte[] payload, Throwable exception) {
+    System.err.println("[" + sessionName + "] STOMP error: " + exception.getMessage());
+    System.err.println("[" + sessionName + "] Command: " + command);
+    System.err.println("[" + sessionName + "] Headers: " + headers);
+    exception.printStackTrace();
+  }
+
+  @Override
+  public void handleTransportError(StompSession session, Throwable exception) {
+    System.err.println("[" + sessionName + "] Transport error: " + exception.getMessage());
+    exception.printStackTrace();
+  }
+
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #41 

## 🪐 작업 내용
### 1. frontend 파일 전체 제거
- 개발 편의성을 위하여 백엔드 파일에서 제거 
- 별도 레포지토리에서 작업할 예정

### 2. 실시간 시청방 채팅 구독 및 메세지 전송 기능 구현 
- Controller 단위 테스트 코드 구현
- WepSocket + Stomp 로 Controller 구현

### 3. 채팅방 컨트롤러 단일 조회 기능 수정
- 단일 조회 pathVariable 명시 
- 컨트롤러 단위 테스트 OAuth2 관련 config 제외

### 4. 채팅방 기능 WebSocket 연결 테스트 코드 구현
- 테스트를 위한 의존성 추가
- WebSocket 연결 테스트 구현
- 테스트 시 Security와 독립 되도록 TestSecurityConfig 추가

### 4. WebSocketConfig 폴더 이동


## 📚 Reference
- [[Spring] 스프링부트 테스트를 위한 의존성과 어노테이션, 애플리케이션 컨택스트 캐싱(@SpringBootTest, @WebMvcTest, @DataJpaTest)](https://mangkyu.tistory.com/242)
- https://docs.spring.io/spring-framework/docs/4.3.x/spring-framework-reference/html/websocket.html#websocket-stomp-testing
- https://docs.spring.io/spring-boot/reference/using/auto-configuration.html#using.auto-configuration
- [Spring boot 3.5.3 공식문서](https://docs.spring.io/spring-framework/reference/web/websocket/stomp/testing.html#page-title)
- [spring-websocket-portfolio](https://github.com/rstoyanchev/spring-websocket-portfolio/tree/main/src/test/java/org/springframework/samples/portfolio/web)
- [JUnit을 이용한 웹소켓 테스트](https://velog.io/@ksp7331/JUnit%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%9B%B9%EC%86%8C%EC%BC%93-%ED%85%8C%EC%8A%A4%ED%8A%B8)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?