### PR TITLE
feat: 단순 전체 컨텐츠 조회와 단일 컨텐츠 조회 구현

### DIFF
--- a/src/main/java/team03/mopl/common/exception/ErrorCode.java
+++ b/src/main/java/team03/mopl/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
   DUPLICATED_EMAIL(HttpStatus.CONFLICT, "USER_002", "이미 사용중인 이메일입니다"),
   DUPLICATED_NAME(HttpStatus.CONFLICT, "USER_003", "이미 사용 중인 사용자명입니다."),
 
+  //Content
   CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTENT_001", "존재하지 않는 콘텐츠입니다."),
 
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_001", "존재하지 않는 리뷰입니다."),

--- a/src/main/java/team03/mopl/domain/content/controller/ContentController.java
+++ b/src/main/java/team03/mopl/domain/content/controller/ContentController.java
@@ -1,0 +1,23 @@
+package team03.mopl.domain.content.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.content.service.ContentService;
+
+@RestController
+@RequestMapping("/api/contents")
+@RequiredArgsConstructor
+public class ContentController {
+
+  private final ContentService contentService;
+
+  @GetMapping
+  public ResponseEntity<List<ContentDto>> getAll(){
+    return ResponseEntity.ok(contentService.getAll());
+  }
+}

--- a/src/main/java/team03/mopl/domain/content/controller/ContentController.java
+++ b/src/main/java/team03/mopl/domain/content/controller/ContentController.java
@@ -1,9 +1,11 @@
 package team03.mopl.domain.content.controller;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team03.mopl.domain.content.dto.ContentDto;
@@ -17,7 +19,12 @@ public class ContentController {
   private final ContentService contentService;
 
   @GetMapping
-  public ResponseEntity<List<ContentDto>> getAll(){
+  public ResponseEntity<List<ContentDto>> getAll() {
     return ResponseEntity.ok(contentService.getAll());
+  }
+
+  @GetMapping("/{contentId}")
+  public ResponseEntity<ContentDto> getContent(@PathVariable("contentId") UUID id) {
+    return ResponseEntity.ok(contentService.getContent(id));
   }
 }

--- a/src/main/java/team03/mopl/domain/content/service/ContentService.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentService.java
@@ -7,6 +7,7 @@ import team03.mopl.domain.content.dto.ContentDto;
 public interface ContentService {
 
   List<ContentDto> getAll();
+  ContentDto getContent(UUID id);
 
   void updateContentRating(UUID contentId);
 }

--- a/src/main/java/team03/mopl/domain/content/service/ContentService.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentService.java
@@ -1,8 +1,12 @@
 package team03.mopl.domain.content.service;
 
+import java.util.List;
 import java.util.UUID;
+import team03.mopl.domain.content.dto.ContentDto;
 
 public interface ContentService {
+
+  List<ContentDto> getAll();
 
   void updateContentRating(UUID contentId);
 }

--- a/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
@@ -29,6 +29,14 @@ public class ContentServiceImpl implements ContentService {
   }
 
   @Override
+  public ContentDto getContent(UUID id) {
+    // 컨텐츠 존재 유무 검증
+    Content content = contentRepository.findById(id)
+        .orElseThrow(ContentNotFoundException::new);
+    return ContentDto.from(content);
+  }
+
+  @Override
   public void updateContentRating(UUID contentId) {
     BigDecimal averageRating = calculateRating(contentId);
 

--- a/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.repository.ContentRepository;
 import team03.mopl.domain.review.dto.ReviewResponse;
 import team03.mopl.domain.review.service.ReviewService;
@@ -19,6 +20,13 @@ public class ContentServiceImpl implements ContentService {
 
   private final ContentRepository contentRepository;
   private final ReviewService reviewService;
+
+  @Override
+  public List<ContentDto> getAll() {
+    return contentRepository.findAll()
+        .stream().map(ContentDto::from)
+        .toList();
+  }
 
   @Override
   public void updateContentRating(UUID contentId) {

--- a/src/test/java/team03/mopl/domain/content/controller/ContentControllerTest.java
+++ b/src/test/java/team03/mopl/domain/content/controller/ContentControllerTest.java
@@ -1,0 +1,97 @@
+package team03.mopl.domain.content.controller;
+
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.content.service.ContentService;
+
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(ContentController.class)
+@DisplayName("컨텐츠 데이터 컨트롤러 단위 테스트")
+class ContentControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @MockitoBean
+  private ContentService contentService;
+
+  @Nested
+  @DisplayName("전체 컨텐츠 데이터 조회")
+  class getContents {
+
+    @Test
+    @DisplayName("성공 - 데이터 있음")
+    void success() throws Exception {
+      // given
+      Content content1 = Content.builder()
+          .title("테스트 컨텐츠1")
+          .description("설명1")
+          .contentType(ContentType.MOVIE)
+          .releaseDate(LocalDateTime.now())
+          .build();
+      Content content2 = Content.builder()
+          .title("테스트 컨텐츠2")
+          .description("설명2")
+          .contentType(ContentType.SPORTS)
+          .releaseDate(LocalDateTime.now())
+          .build();
+      ContentDto contentDto1 = ContentDto.from(content1);
+      ContentDto contentDto2 = ContentDto.from(content2);
+      List<ContentDto> contentsDtos = List.of(contentDto1, contentDto2);
+
+      when(contentService.getAll()).thenReturn(contentsDtos);
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/api/contents"));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.length()").value(2))
+          .andExpect(jsonPath("$[0].title").value("테스트 컨텐츠1"))
+          .andExpect(jsonPath("$[0].description").value("설명1"))
+          .andExpect(jsonPath("$[0].contentType").value(ContentType.MOVIE.toString()))
+          .andExpect(jsonPath("$[1].title").value("테스트 컨텐츠2"))
+          .andExpect(jsonPath("$[1].description").value("설명2"))
+          .andExpect(jsonPath("$[1].contentType").value(ContentType.SPORTS.toString()));
+    }
+
+
+    @Test
+    @DisplayName("성공 - 데이터 없음")
+    void success_whenNoContent() throws Exception {
+      // given
+      when(contentService.getAll()).thenReturn(Collections.emptyList());
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/api/contents"));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.length()").value(0));
+    }
+  }
+}
+
+

--- a/src/test/java/team03/mopl/domain/content/integration/ContentIntegrationTest.java
+++ b/src/test/java/team03/mopl/domain/content/integration/ContentIntegrationTest.java
@@ -1,0 +1,81 @@
+package team03.mopl.domain.content.integration;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.repository.ContentRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@WithMockUser
+@DisplayName("컨텐츠 통합 테스트")
+public class ContentIntegrationTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ContentRepository contentRepository;
+
+  @Nested
+  @DisplayName("콘텐츠 데이터 조회")
+  class getContent{
+    @Test
+    @DisplayName("성공 - 존재하는 ID로 컨텐츠 조회시 200 OK, 컨텐츠 정보 반환")
+    void getContent_success() throws Exception {
+      // given
+      Content savedContent = contentRepository.save( Content.builder()
+          .title("통합 테스트용 컨텐츠")
+          .description("설명")
+          .contentType(ContentType.MOVIE)
+          .releaseDate(LocalDateTime.now())
+          .build()
+      );
+      UUID saveId = savedContent.getId();
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/api/contents/{contentId}", saveId));
+
+      // then
+      actions
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(saveId.toString()))
+          .andExpect(jsonPath("$.title").value("통합 테스트용 컨텐츠"))
+          .andExpect(jsonPath("$.description").value("설명"));
+    }
+
+    @Test
+    @DisplayName("성공 - 존재하지 않는 ID로 컨텐츠 조회시 400 Not Found 반환")
+    void getContent_Fail() throws Exception {
+      // given
+      UUID nonExistingId = UUID.randomUUID();
+
+      // when
+      ResultActions actions = mockMvc.perform(get("/api/contents/{contentId}", nonExistingId));
+
+      // then
+      actions
+          .andExpect(status().isNotFound());
+    }
+  }
+
+}

--- a/src/test/java/team03/mopl/domain/content/service/ContentServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/content/service/ContentServiceImplTest.java
@@ -1,0 +1,77 @@
+package team03.mopl.domain.content.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team03.mopl.common.exception.content.ContentNotFoundException;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.content.repository.ContentRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("컨텐츠 데이터 서비스 단위 테스트")
+class ContentServiceImplTest {
+
+  @Mock
+  private ContentRepository contentRepository;
+
+  @InjectMocks
+  private ContentServiceImpl contentService;
+
+  @Nested
+  @DisplayName("컨텐츠 데이터 조회")
+  class getContent {
+
+    @Test
+    @DisplayName("컨텐츠 데이터 조회 성공")
+    void success(){
+      // given
+      UUID id = UUID.randomUUID();
+      Content content = Content.builder()
+          .title("테스트 컨텐츠")
+          .description("설명")
+          .contentType(ContentType.MOVIE)
+          .releaseDate(LocalDateTime.now())
+          .build();
+
+      when(contentRepository.findById(id)).thenReturn(Optional.of(content));
+
+      // when
+      ContentDto result = contentService.getContent(id);
+
+      // then
+      assertThat(result.title()).isEqualTo("테스트 컨텐츠");
+      assertThat(result.description()).isEqualTo("설명");
+      assertThat(result.contentType()).isEqualTo(ContentType.MOVIE);
+
+      verify(contentRepository, times(1)).findById(id);
+    }
+
+    @Test
+    @DisplayName("컨텐츠 데이터 조회 실패 - 존재하지 않는 컨텐츠")
+    void fail_WhenNoContent(){
+      //given
+      UUID nonExistingid = UUID.randomUUID();
+      when(contentRepository.findById(nonExistingid)).thenReturn(Optional.empty());
+
+      // when, then
+      assertThrows(ContentNotFoundException.class, () -> contentService.getContent(nonExistingid));
+
+      verify(contentRepository, times(1)).findById(nonExistingid);
+    }
+  }
+}


### PR DESCRIPTION
## 🛰️ Issue Number

- #59 

## 🪐 작업 내용
1. 단순 컨텐츠 전체 조회
단순하고 Service, Repository 쪽에 특별한 로직이 많이 들어가지 않으므로 클라이언트 측에 데이터를 잘 보내는지만 확인하기 위해 컨트롤러 단위 테스트만 진행

3. 단일 컨텐츠 조회
존재 여부에 따라서 분기(1. 있음 → 콘텐츠 반환, 2 없음 → 에러)가 발생하므로
로직이 들어가는 Service 단위 테스트 작성, 예외 핸들링이 잘 되고 있는지 파악하기 위해 통합 테스트 진행

## 📚 Reference

## 오류 기록
[@PathVariable("이름 넣는 거 까먹어서 생겼던 오류")](https://lightning-shell-5dc.notion.site/message-Name-for-argument-of-type-java-util-UUID-not-specified-and-parameter-name-information-n-225ea008b61c80fc8af4ea4f6f9d8dc2?source=copy_link)

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?