### PR TITLE
docs: chat -> watch 변경, 유저 profile_image 필드 추가로 인한 schema.sql 수정

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -23,13 +23,13 @@ CREATE TABLE "contents"
     "description"  TEXT                    NULL,
     "content_type" VARCHAR(50)             NOT NULL,
     "release_date" TIMESTAMP               NOT NULL,
-    "avg_rating"   DECIMAL(3,2)            NULL CHECK (avg_rating    >= 0.0 AND avg_rating <= 5.0),
+    "avg_rating"   DECIMAL(3, 2)           NULL CHECK (avg_rating >= 0.0 AND avg_rating <= 5.0),
     "created_at"   TIMESTAMP DEFAULT now() NOT NULL,
     "url"          TEXT                    NULL
 );
 COMMENT ON COLUMN "contents"."content_type" IS 'ENUM';
-CREATE INDEX idx_content_title ON contents(title);
-CREATE INDEX idx_content_description ON contents(description);
+CREATE INDEX idx_content_title ON contents (title);
+CREATE INDEX idx_content_description ON contents (description);
 
 -- 키워드 테이블
 CREATE TABLE "keywords"
@@ -61,7 +61,7 @@ CREATE TABLE "reviews"
     "content_id" UUID                    NOT NULL,
     "title"      VARCHAR(255)            NOT NULL,
     "comment"    TEXT                    NULL,
-    "rating"     DECIMAL(2,1)            NOT NULL CHECK (rating >= 0.0 AND rating <= 5.0),
+    "rating"     DECIMAL(2, 1)           NOT NULL CHECK (rating >= 0.0 AND rating <= 5.0),
     "created_at" TIMESTAMP DEFAULT now() NOT NULL,
     "updated_at" TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("user_id", "content_id"),
@@ -118,30 +118,33 @@ CREATE TABLE "follows"
 );
 
 -- 채팅&시청방 테이블
-CREATE TABLE "chat_rooms"
+CREATE TABLE "watch_rooms"
 (
-    "id"         UUID PRIMARY KEY        NOT NULL,
-    "content_id" UUID                    NOT NULL,
-    "owner_id"   UUID                    NOT NULL,
-    "created_at" TIMESTAMP DEFAULT now() NOT NULL,
+    "id"                     UUID PRIMARY KEY               NOT NULL,
+    "content_id"             UUID                           NOT NULL,
+    "owner_id"               UUID                           NOT NULL,
+    "created_at"             TIMESTAMP        DEFAULT now() NOT NULL,
+    "current_time"           DOUBLE PRECISION DEFAULT 0.0   NOT NULL,
+    "is_playing"             BOOLEAN          DEFAULT FALSE NOT NULL,
+    "video_state_updated_at" TIMESTAMP        DEFAULT now() NOT NULL,
     FOREIGN KEY ("owner_id") REFERENCES "users" ("id"),
     FOREIGN KEY ("content_id") REFERENCES "contents" ("id")
 );
 
 -- 채팅 메시지 테이블
-CREATE TABLE "chat_messages"
+CREATE TABLE "watch_room_messages"
 (
     "id"         UUID PRIMARY KEY        NOT NULL,
     "room_id"    UUID                    NOT NULL,
     "sender_id"  UUID                    NOT NULL,
     "content"    VARCHAR(255)            NOT NULL,
     "created_at" TIMESTAMP DEFAULT now() NOT NULL,
-    FOREIGN KEY ("room_id") REFERENCES "chat_rooms" ("id"),
+    FOREIGN KEY ("room_id") REFERENCES "watch_rooms" ("id"),
     FOREIGN KEY ("sender_id") REFERENCES "users" ("id")
 );
 
 -- 채팅방 참가자 테이블
-CREATE TABLE "chat_room_participants"
+CREATE TABLE "watch_room_participants"
 (
     "id"         UUID PRIMARY KEY        NOT NULL,
     "user_id"    UUID                    NOT NULL,
@@ -149,7 +152,7 @@ CREATE TABLE "chat_room_participants"
     "created_at" TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("user_id", "room_id"),
     FOREIGN KEY ("user_id") REFERENCES "users" ("id"),
-    FOREIGN KEY ("room_id") REFERENCES "chat_rooms" ("id")
+    FOREIGN KEY ("room_id") REFERENCES "watch_rooms" ("id")
 );
 
 -- DM 룸 테이블
@@ -207,7 +210,7 @@ CREATE TABLE "jwt_sessions"
 
 CREATE TABLE "dm_read_users"
 (
-    "dm_id" UUID NOT NULL,
+    "dm_id"   UUID NOT NULL,
     "user_id" UUID NOT NULL,
     PRIMARY KEY ("dm_id", "user_id"),
     FOREIGN KEY ("dm_id") REFERENCES "dms" ("id")

--- a/init/schema.sql
+++ b/init/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE "users"
     "updated_at"               TIMESTAMP   DEFAULT now()  NOT NULL,
     "is_locked"                BOOLEAN     DEFAULT false  NOT NULL,
     "role"                     VARCHAR(50) DEFAULT 'USER' NOT NULL,
+    "profile_image"            VARCHAR(255)               NULL,
     "is_temp_password"         BOOLEAN     DEFAULT false  NOT NULL,
     "temp_password_expired_at" TIMESTAMP                  NULL
 );

--- a/src/main/java/team03/mopl/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/team03/mopl/domain/chat/entity/ChatMessage.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@Table(name="chat_messages")
+@Table(name="watch_room_messages")
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/team03/mopl/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/team03/mopl/domain/chat/entity/ChatRoom.java
@@ -1,13 +1,18 @@
 package team03.mopl.domain.chat.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -16,15 +21,17 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import team03.mopl.domain.content.Content;
 
 
 @Entity
-@Table(name = "chat_rooms")
+@Table(name = "watch_rooms")
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(value = {EntityListeners.class})
 public class ChatRoom {
 
   @Id
@@ -42,7 +49,56 @@ public class ChatRoom {
   @JoinColumn(name = "content_id", nullable = false)
   private Content content;
 
-  public ChatRoom(Content content) {
-    this.content = content;
+  @Column(name = "current_time")
+  @Builder.Default
+  private Double currentTime = 0.0;
+
+  @Column(name = "is_playing")
+  @Builder.Default
+  private Boolean isPlaying = false;
+
+  @Column(name = "video_state_updated_at")
+  private LocalDateTime videoStateUpdatedAt;
+
+  //재생
+  public void play() {
+    this.isPlaying = true;
+    this.videoStateUpdatedAt = LocalDateTime.now();
+  }
+
+  //일시정지
+  public void pause() {
+    this.currentTime = calculateRealCurrentTime();
+    this.isPlaying = false;
+    this.videoStateUpdatedAt = LocalDateTime.now();
+  }
+
+  // 특정 시간대로 이동
+  public void seekTo(double newTime) {
+    this.currentTime = newTime;
+    this.videoStateUpdatedAt = LocalDateTime.now();
+  }
+
+  //경과 시간 계산
+  public double calculateRealCurrentTime() {
+    if (!this.isPlaying || this.videoStateUpdatedAt == null) {
+      return this.currentTime;
+    }
+
+    LocalDateTime now = LocalDateTime.now();
+    Duration elapsed = Duration.between(this.videoStateUpdatedAt, now);
+    double elapsedSeconds = elapsed.toMillis() / 1000.0;
+
+    return this.currentTime + elapsedSeconds;
+  }
+
+  //방장 변경
+  public void changeOwner(UUID newOwnerId) {
+    this.ownerId = newOwnerId;
+  }
+
+  //방장인지 확인
+  public boolean isOwner(UUID userId) {
+    return this.ownerId.equals(userId);
   }
 }

--- a/src/main/java/team03/mopl/domain/chat/entity/ChatRoomParticipant.java
+++ b/src/main/java/team03/mopl/domain/chat/entity/ChatRoomParticipant.java
@@ -14,15 +14,17 @@ import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import team03.mopl.domain.user.User;
 
 @Entity
-@Table(name = "chat_room_participants", uniqueConstraints = {
+@Table(name = "watch_room_participants", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"user_id", "room_id"})
 })
 @Builder
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatRoomParticipant {


### PR DESCRIPTION
## 🪐 작업 내용
- chat_rooms 필드 추가( current_time, is_playing, video_state_updated_at) 및
테이블명 watch_rooms로 변경
- chat_messages → watch_room_messages로 테이블명 변경
- chat_room_participants → watch_room_participants로 테이블명 변경

- User 엔티티 profile_image 필드 추가

## 📚 Reference
- #69 

## 기타
 제가 제거 머지하는걸 깜박해서 이전 PR 내용이 같이 들어갔었습니다. 수정된 부분만 들어가게 하고싶어서 열었다 닫았다 했습니다. 헷갈리게 해드렸다면 죄송합니다. 😢 

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?