### PR TITLE
fix: watch_rooms 테이블의 currnet_time 필드명 play_time으로 수정

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -125,7 +125,7 @@ CREATE TABLE "watch_rooms"
     "content_id"             UUID                           NOT NULL,
     "owner_id"               UUID                           NOT NULL,
     "created_at"             TIMESTAMP        DEFAULT now() NOT NULL,
-    "current_time"           DOUBLE PRECISION DEFAULT 0.0   NOT NULL,
+    "play_time"           DOUBLE PRECISION DEFAULT 0.0   NOT NULL,
     "is_playing"             BOOLEAN          DEFAULT FALSE NOT NULL,
     "video_state_updated_at" TIMESTAMP        DEFAULT now() NOT NULL,
     FOREIGN KEY ("owner_id") REFERENCES "users" ("id"),


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
- watch_rooms 테이블의 currnet_time 필드명 play_time으로 수정 (이유: currnet_time은 예약어)

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?