### PR TITLE
feat: curation service test, controller test 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/team03/mopl/domain/chat/entity/ChatRoom.java
@@ -1,16 +1,13 @@
 package team03.mopl.domain.chat.entity;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -21,7 +18,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import team03.mopl.domain.content.Content;
 
 
@@ -49,9 +45,9 @@ public class ChatRoom {
   @JoinColumn(name = "content_id", nullable = false)
   private Content content;
 
-  @Column(name = "current_time")
+  @Column(name = "play_time")
   @Builder.Default
-  private Double currentTime = 0.0;
+  private Double playTime = 0.0;
 
   @Column(name = "is_playing")
   @Builder.Default
@@ -68,28 +64,28 @@ public class ChatRoom {
 
   //일시정지
   public void pause() {
-    this.currentTime = calculateRealCurrentTime();
+    this.playTime = calculateRealPlayTime();
     this.isPlaying = false;
     this.videoStateUpdatedAt = LocalDateTime.now();
   }
 
   // 특정 시간대로 이동
   public void seekTo(double newTime) {
-    this.currentTime = newTime;
+    this.playTime = newTime;
     this.videoStateUpdatedAt = LocalDateTime.now();
   }
 
   //경과 시간 계산
-  public double calculateRealCurrentTime() {
+  public double calculateRealPlayTime() {
     if (!this.isPlaying || this.videoStateUpdatedAt == null) {
-      return this.currentTime;
+      return this.playTime;
     }
 
     LocalDateTime now = LocalDateTime.now();
     Duration elapsed = Duration.between(this.videoStateUpdatedAt, now);
     double elapsedSeconds = elapsed.toMillis() / 1000.0;
 
-    return this.currentTime + elapsedSeconds;
+    return this.playTime + elapsedSeconds;
   }
 
   //방장 변경

--- a/src/main/java/team03/mopl/domain/curation/entity/Keyword.java
+++ b/src/main/java/team03/mopl/domain/curation/entity/Keyword.java
@@ -12,15 +12,19 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import team03.mopl.domain.user.User;
 
+@Builder
 @Getter
 @Entity
 @Table(name = "keywords")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Keyword {
 
   @Id
@@ -37,9 +41,4 @@ public class Keyword {
   @CreatedDate
   @Column(nullable = false)
   private LocalDateTime createdAt;
-
-  public Keyword(User user, String keyword) {
-    this.user = user;
-    this.keyword = keyword;
-  }
 }

--- a/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
@@ -121,7 +121,10 @@ public class CurationServiceImpl implements CurationService {
     String normalizedKeyword = normalizeMultilingualText(keywordText);
     String language = detectLanguage(keywordText);
 
-    Keyword keyword = new Keyword(user, normalizedKeyword);
+    Keyword keyword = Keyword.builder()
+        .keyword(keywordText)
+        .user(user)
+        .build();
     keyword = keywordRepository.save(keyword);
 
     List<Content> recommendations = curateContentForKeyword(keyword);

--- a/src/test/java/team03/mopl/domain/curation/CurationControllerTest.java
+++ b/src/test/java/team03/mopl/domain/curation/CurationControllerTest.java
@@ -1,0 +1,213 @@
+package team03.mopl.domain.curation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.curation.controller.CurationController;
+import team03.mopl.domain.curation.dto.KeywordRequest;
+import team03.mopl.domain.curation.entity.Keyword;
+import team03.mopl.domain.curation.service.CurationService;
+import team03.mopl.domain.user.Role;
+import team03.mopl.domain.user.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("큐레이션 컨트롤러 테스트")
+class CurationControllerTest {
+
+  @Mock
+  private CurationService curationService;
+
+  @InjectMocks
+  private CurationController curationController;
+
+  @Nested
+  @DisplayName("키워드 등록 요청")
+  class RegisterKeyword {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      String keywordText = "액션";
+
+      KeywordRequest request = new KeywordRequest(userId, keywordText);
+
+      User mockUser = User.builder()
+          .id(userId)
+          .name("테스트유저")
+          .email("test@test.com")
+          .password("test")
+          .role(Role.USER)
+          .build();
+
+      Keyword mockKeyword = Keyword.builder()
+          .user(mockUser)
+          .keyword(keywordText)
+          .build();
+
+      when(curationService.registerKeyword(userId, keywordText)).thenReturn(mockKeyword);
+
+      // when
+      ResponseEntity<Keyword> response = curationController.registerKeyword(request);
+
+      // then
+      assertNotNull(response.getBody());
+      assertEquals(keywordText, response.getBody().getKeyword());
+      assertEquals(mockUser, response.getBody().getUser());
+
+      verify(curationService).registerKeyword(userId, keywordText);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저")
+    void failsWhenUserNotFound() {
+      // given
+      UUID userId = UUID.randomUUID();
+      String keywordText = "액션";
+
+      KeywordRequest request = new KeywordRequest(userId, keywordText);
+
+      when(curationService.registerKeyword(userId, keywordText)).thenThrow(new UserNotFoundException());
+
+      // when & then
+      assertThrows(UserNotFoundException.class, () -> curationController.registerKeyword(request));
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 추천 콘텐츠 조회 요청")
+  class GetRecommendations {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      UUID userId = UUID.randomUUID();
+      int limit = 10;
+
+      Content mockContent1 = Content.builder()
+          .id(UUID.randomUUID())
+          .title("액션 영화")
+          .description("액션과 모험이 가득한 영화")
+          .contentType(ContentType.MOVIE)
+          .releaseDate(LocalDateTime.now())
+          .avgRating(BigDecimal.valueOf(4.5))
+          .build();
+
+      Content mockContent2 = Content.builder()
+          .id(UUID.randomUUID())
+          .title("스릴러 드라마")
+          .description("긴장감 넘치는 드라마")
+          .contentType(ContentType.TV)
+          .releaseDate(LocalDateTime.now())
+          .avgRating(BigDecimal.valueOf(4.0))
+          .build();
+
+      List<Content> mockRecommendations = List.of(mockContent1, mockContent2);
+
+      when(curationService.getRecommendationsForUser(userId, limit)).thenReturn(mockRecommendations);
+
+      // when
+      ResponseEntity<List<Content>> response = curationController.getRecommendations(userId, limit);
+
+      // then
+      assertNotNull(response.getBody());
+      assertEquals(2, response.getBody().size());
+      assertEquals(mockContent1.getTitle(), response.getBody().get(0).getTitle());
+      assertEquals(mockContent2.getTitle(), response.getBody().get(1).getTitle());
+
+      verify(curationService).getRecommendationsForUser(userId, limit);
+    }
+
+    @Test
+    @DisplayName("기본 limit 값 사용")
+    void successWithDefaultLimit() {
+      // given
+      UUID userId = UUID.randomUUID();
+      int defaultLimit = 10;
+
+      List<Content> mockRecommendations = List.of();
+
+      when(curationService.getRecommendationsForUser(userId, defaultLimit)).thenReturn(mockRecommendations);
+
+      // when
+      ResponseEntity<List<Content>> response = curationController.getRecommendations(userId, defaultLimit);
+
+      // then
+      assertNotNull(response.getBody());
+      assertTrue(response.getBody().isEmpty());
+
+      verify(curationService).getRecommendationsForUser(userId, defaultLimit);
+    }
+
+    @Test
+    @DisplayName("빈 추천 목록 반환")
+    void returnsEmptyRecommendations() {
+      // given
+      UUID userId = UUID.randomUUID();
+      int limit = 5;
+
+      List<Content> emptyRecommendations = List.of();
+
+      when(curationService.getRecommendationsForUser(userId, limit)).thenReturn(emptyRecommendations);
+
+      // when
+      ResponseEntity<List<Content>> response = curationController.getRecommendations(userId, limit);
+
+      // then
+      assertNotNull(response.getBody());
+      assertTrue(response.getBody().isEmpty());
+
+      verify(curationService).getRecommendationsForUser(userId, limit);
+    }
+
+    @Test
+    @DisplayName("limit 값보다 적은 추천 콘텐츠")
+    void returnsFewerThanLimit() {
+      // given
+      UUID userId = UUID.randomUUID();
+      int limit = 10;
+
+      Content mockContent = Content.builder()
+          .id(UUID.randomUUID())
+          .title("유일한 추천 콘텐츠")
+          .description("추천된 유일한 콘텐츠")
+          .contentType(ContentType.MOVIE)
+          .releaseDate(LocalDateTime.now())
+          .avgRating(BigDecimal.valueOf(3.5))
+          .build();
+
+      List<Content> mockRecommendations = List.of(mockContent);
+
+      when(curationService.getRecommendationsForUser(userId, limit)).thenReturn(mockRecommendations);
+
+      // when
+      ResponseEntity<List<Content>> response = curationController.getRecommendations(userId, limit);
+
+      // then
+      assertNotNull(response.getBody());
+      assertEquals(1, response.getBody().size());
+      assertTrue(response.getBody().size() < limit);
+      assertEquals(mockContent.getTitle(), response.getBody().get(0).getTitle());
+
+      verify(curationService).getRecommendationsForUser(userId, limit);
+    }
+  }
+}

--- a/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
@@ -1,0 +1,414 @@
+package team03.mopl.domain.curation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.curation.entity.Keyword;
+import team03.mopl.domain.curation.entity.KeywordContent;
+import team03.mopl.domain.curation.repository.KeywordContentRepository;
+import team03.mopl.domain.curation.repository.KeywordRepository;
+import team03.mopl.domain.curation.service.CurationServiceImpl;
+import team03.mopl.domain.review.dto.ReviewResponse;
+import team03.mopl.domain.review.service.ReviewService;
+import team03.mopl.domain.user.Role;
+import team03.mopl.domain.user.User;
+import team03.mopl.domain.user.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("큐레이션 서비스 테스트")
+class CurationServiceImplTest {
+
+  @Mock
+  private ReviewService reviewService;
+
+  @Mock
+  private ContentRepository contentRepository;
+
+  @Mock
+  private KeywordRepository keywordRepository;
+
+  @Mock
+  private KeywordContentRepository keywordContentRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @InjectMocks
+  private CurationServiceImpl curationService;
+
+  // 테스트용 유저
+  private UUID userId;
+  private User user;
+
+  // 테스트용 콘텐츠
+  private UUID contentId;
+  private Content content;
+
+  // 테스트용 키워드
+  private UUID keywordId;
+  private Keyword keyword;
+
+  @BeforeEach
+  void setUp() {
+    userId = UUID.randomUUID();
+    user = User.builder()
+        .id(userId)
+        .name("테스트유저")
+        .email("test@test.com")
+        .password("test")
+        .role(Role.USER)
+        .build();
+
+    contentId = UUID.randomUUID();
+    content = Content.builder()
+        .id(contentId)
+        .title("테스트 액션 영화")
+        .description("액션과 모험이 가득한 영화입니다.")
+        .contentType(ContentType.MOVIE)
+        .releaseDate(LocalDateTime.now())
+        .avgRating(BigDecimal.valueOf(4.5))
+        .build();
+
+    keywordId = UUID.randomUUID();
+    keyword = Keyword.builder()
+        .user(user)
+        .keyword("액션")
+        .build();
+  }
+
+  private void setupKeywordMock() {
+    keyword = mock(Keyword.class);
+    when(keyword.getId()).thenReturn(keywordId);
+    when(keyword.getUser()).thenReturn(user);
+    when(keyword.getKeyword()).thenReturn("액션");
+  }
+
+  @Nested
+  @DisplayName("키워드 등록")
+  class RegisterKeyword {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      String keywordText = "액션";
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(keywordRepository.save(any(Keyword.class))).thenReturn(keyword);
+      when(contentRepository.findAll()).thenReturn(List.of(content));
+      when(keywordContentRepository.save(any(KeywordContent.class))).thenReturn(new KeywordContent(keyword, content));
+
+      // when
+      Keyword result = curationService.registerKeyword(userId, keywordText);
+
+      // then
+      assertNotNull(result);
+      assertEquals("액션", result.getKeyword());
+      assertEquals(user, result.getUser());
+
+      verify(keywordRepository, times(1)).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저")
+    void failsWhenUserNotFound() {
+      // given
+      UUID randomUserId = UUID.randomUUID();
+      String keywordText = "액션";
+
+      when(userRepository.findById(randomUserId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThrows(UserNotFoundException.class,
+          () -> curationService.registerKeyword(randomUserId, keywordText));
+
+      verify(keywordRepository, never()).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("다국어 키워드 정규화")
+    void normalizeMultilingualKeyword() {
+      // given
+      String keywordText = "Action Movie!!!";
+
+      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+      when(keywordRepository.save(any(Keyword.class))).thenReturn(keyword);
+      when(contentRepository.findAll()).thenReturn(List.of());
+
+      // when
+      Keyword result = curationService.registerKeyword(userId, keywordText);
+
+      // then
+      assertNotNull(result);
+      verify(keywordRepository, times(1)).save(any(Keyword.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("키워드별 콘텐츠 큐레이션")
+  class CurateContentForKeyword {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      Content actionMovie = Content.builder()
+          .id(UUID.randomUUID())
+          .title("액션 블록버스터")
+          .description("최고의 액션 영화")
+          .contentType(ContentType.MOVIE)
+          .avgRating(BigDecimal.valueOf(4.8))
+          .build();
+
+      Content dramaMovie = Content.builder()
+          .id(UUID.randomUUID())
+          .title("감동 드라마")
+          .description("가족 이야기")
+          .contentType(ContentType.MOVIE)
+          .avgRating(BigDecimal.valueOf(4.0))
+          .build();
+
+      when(contentRepository.findAll()).thenReturn(List.of(actionMovie, dramaMovie));
+      when(keywordContentRepository.save(any(KeywordContent.class))).thenReturn(new KeywordContent(keyword, actionMovie));
+
+      // when
+      List<Content> result = curationService.curateContentForKeyword(keyword);
+
+      // then
+      assertNotNull(result);
+      // 액션 관련 콘텐츠가 더 높은 점수를 받아야 함
+      assertTrue(result.stream().anyMatch(c -> c.getTitle().contains("액션")));
+    }
+
+    @Test
+    @DisplayName("매칭되는 콘텐츠가 없는 경우")
+    void noMatchingContent() {
+      // given
+      Content unrelatedContent = Content.builder()
+          .id(UUID.randomUUID())
+          .title("로맨틱 코미디")
+          .description("사랑 이야기")
+          .contentType(ContentType.MOVIE)
+          .avgRating(BigDecimal.valueOf(3.0))
+          .build();
+
+      when(contentRepository.findAll()).thenReturn(List.of(unrelatedContent));
+
+      // when
+      List<Content> result = curationService.curateContentForKeyword(keyword);
+
+      // then
+      assertNotNull(result);
+      // 임계값 이하의 콘텐츠는 포함되지 않아야 함
+    }
+  }
+
+  @Nested
+  @DisplayName("사용자 추천 콘텐츠 조회")
+  class GetRecommendationsForUser {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      int limit = 5;
+
+      // 이 테스트에서는 keyword.getId()만 필요하므로 최소한의 Mock 설정
+      keyword = mock(Keyword.class);
+      when(keyword.getId()).thenReturn(keywordId);
+
+      KeywordContent keywordContent = new KeywordContent(keyword, content);
+
+      when(keywordRepository.findAllByUserId(userId)).thenReturn(List.of(keyword));
+      when(keywordContentRepository.findByKeywordId(keywordId)).thenReturn(List.of(keywordContent));
+
+      // when
+      List<Content> result = curationService.getRecommendationsForUser(userId, limit);
+
+      // then
+      assertNotNull(result);
+      assertTrue(result.size() <= limit);
+      assertEquals(content, result.get(0));
+
+      verify(keywordRepository, times(1)).findAllByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("등록된 키워드가 없는 경우")
+    void noRegisteredKeywords() {
+      // given
+      int limit = 5;
+
+      when(keywordRepository.findAllByUserId(userId)).thenReturn(List.of());
+
+      // when
+      List<Content> result = curationService.getRecommendationsForUser(userId, limit);
+
+      // then
+      assertNotNull(result);
+      assertTrue(result.isEmpty());
+
+      verify(keywordRepository, times(1)).findAllByUserId(userId);
+    }
+  }
+
+  // TODO: 배치 큐레이션
+//  @Nested
+//  @DisplayName("신규 콘텐츠 배치 큐레이션")
+//  class BatchCurationForNewContents {
+//
+//    @Test
+//    @DisplayName("성공")
+//    void success() {
+//      // given
+//      List<Content> newContents = List.of(content);
+//
+//      when(keywordRepository.findAll()).thenReturn(List.of(keyword));
+//
+//      // when
+//      curationService.batchCurationForNewContents(newContents);
+//
+//      // then
+//      verify(keywordRepository, times(1)).findAll();
+//    }
+//
+//    @Test
+//    @DisplayName("이미 존재하는 키워드-콘텐츠 관계")
+//    void alreadyExistingRelation() {
+//      // given
+//      List<Content> newContents = List.of(content);
+//      setupKeywordMock(); // Mock 설정
+//
+//      when(keywordRepository.findAll()).thenReturn(List.of(keyword));
+//      when(keywordContentRepository.existsByKeywordIdAndContentId(keywordId, contentId)).thenReturn(true);
+//
+//      // when
+//      curationService.batchCurationForNewContents(newContents);
+//
+//      // then
+//      verify(keywordContentRepository, never()).save(any(KeywordContent.class));
+//    }
+//
+//    @Test
+//    @DisplayName("빈 콘텐츠 리스트")
+//    void emptyContentList() {
+//      // given
+//      List<Content> newContents = List.of();
+//
+//      // when
+//      curationService.batchCurationForNewContents(newContents);
+//
+//      // then
+//      verify(keywordRepository, times(1)).findAll();
+//      verify(keywordContentRepository, never()).save(any(KeywordContent.class));
+//    }
+//  }
+
+  @Nested
+  @DisplayName("콘텐츠 평점 업데이트")
+  class UpdateContentRating {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      // given
+      ReviewResponse review1 = new ReviewResponse(
+          "좋은 영화",
+          "재미있어요",
+          BigDecimal.valueOf(5)
+      );
+
+      ReviewResponse review2 = new ReviewResponse(
+          "괜찮은 영화",
+          "보통이에요",
+          BigDecimal.valueOf(3)
+      );
+
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+      when(reviewService.findAllByContent(contentId)).thenReturn(List.of(review1, review2));
+      when(contentRepository.save(any(Content.class))).thenReturn(content);
+
+      // when
+      curationService.updateContentRating(contentId);
+
+      // then
+      verify(contentRepository, times(1)).save(any(Content.class));
+      verify(reviewService, times(1)).findAllByContent(contentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠")
+    void failsWhenContentNotFound() {
+      // given
+      UUID randomContentId = UUID.randomUUID();
+
+      when(contentRepository.findById(randomContentId)).thenReturn(Optional.empty());
+
+      // when
+      curationService.updateContentRating(randomContentId);
+
+      // then
+      verify(contentRepository, never()).save(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 경우")
+    void noReviews() {
+      // given
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+      when(reviewService.findAllByContent(contentId)).thenReturn(List.of());
+      when(contentRepository.save(any(Content.class))).thenReturn(content);
+
+      // when
+      curationService.updateContentRating(contentId);
+
+      // then
+      verify(contentRepository, times(1)).save(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("평점이 null인 리뷰가 포함된 경우")
+    void reviewsWithNullRating() {
+      // given
+      ReviewResponse reviewWithNullRating = new ReviewResponse(
+          "평점 없는 리뷰",
+          "평점을 주지 않았어요",
+          null
+      );
+
+      ReviewResponse normalReview = new ReviewResponse(
+          "일반 리뷰",
+          "좋아요",
+          BigDecimal.valueOf(4)
+      );
+
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+      when(reviewService.findAllByContent(contentId)).thenReturn(List.of(reviewWithNullRating, normalReview));
+      when(contentRepository.save(any(Content.class))).thenReturn(content);
+
+      // when
+      curationService.updateContentRating(contentId);
+
+      // then
+      verify(contentRepository, times(1)).save(any(Content.class));
+    }
+  }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
- #62 

Close #62 

## 🪐 작업 내용
1. curation domain에 대한 service, controller 테스트 코드 추가
2. keyword entity에서 생성자 대신 builder 패턴 사용
 - curationServiceImpl 코드 수정
3. ChatRoom entity 필드 수정
 - currentTime 필드가 schema와 일치하지 않아 playTime으로 변경

## 추가적으로 해야 할 사항
- curation 배치 처리

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?