### PR TITLE
fix: follow 관련 조회 기능 응답 DTO 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/follow/controller/FollowController.java
+++ b/src/main/java/team03/mopl/domain/follow/controller/FollowController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team03.mopl.domain.follow.dto.FollowRequest;
+import team03.mopl.domain.follow.dto.FollowResponse;
 import team03.mopl.domain.follow.service.FollowService;
 import team03.mopl.domain.user.UserResponse;
 
@@ -36,7 +37,7 @@ public class FollowController {
 
   // 팔로잉 목록
   @GetMapping("/{userId}/following")
-  public ResponseEntity<List<UserResponse>> getFollowing(
+  public ResponseEntity<List<FollowResponse>> getFollowing(
       @PathVariable(name = "userId") UUID userId
   ) {
     return ResponseEntity.ok(followService.getFollowing(userId));
@@ -44,7 +45,7 @@ public class FollowController {
 
   // 팔로워 목록
   @GetMapping("/{userId}/followers")
-  public ResponseEntity<List<UserResponse>> getFollowers(
+  public ResponseEntity<List<FollowResponse>> getFollowers(
       @PathVariable(name = "userId") UUID userId
   ) {
     return ResponseEntity.ok(followService.getFollowers(userId));

--- a/src/main/java/team03/mopl/domain/follow/dto/FollowResponse.java
+++ b/src/main/java/team03/mopl/domain/follow/dto/FollowResponse.java
@@ -1,0 +1,22 @@
+package team03.mopl.domain.follow.dto;
+
+
+import java.util.UUID;
+import team03.mopl.domain.user.UserResponse;
+
+public record FollowResponse(
+    UUID id,
+    String email,
+    String name,
+    String role,
+    String profileImage
+) {
+
+  public static FollowResponse fromUserResponse(UUID id, UserResponse userResponse) {
+    return new FollowResponse(id,
+        userResponse.email(),
+        userResponse.name(),
+        userResponse.role(),
+        userResponse.profileImage());
+  }
+}

--- a/src/main/java/team03/mopl/domain/follow/entity/Follow.java
+++ b/src/main/java/team03/mopl/domain/follow/entity/Follow.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.follow.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,11 +13,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "follows")
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Follow {
 
   @Id

--- a/src/main/java/team03/mopl/domain/follow/service/FollowService.java
+++ b/src/main/java/team03/mopl/domain/follow/service/FollowService.java
@@ -2,13 +2,13 @@ package team03.mopl.domain.follow.service;
 
 import java.util.List;
 import java.util.UUID;
-import team03.mopl.domain.user.UserResponse;
+import team03.mopl.domain.follow.dto.FollowResponse;
 
 public interface FollowService {
   void follow(UUID followerId, UUID followingId);
   void unfollow(UUID followerId, UUID followingId);
-  List<UserResponse> getFollowing(UUID userId);   // 내가 팔로우한 사람 목록
-  List<UserResponse> getFollowers(UUID userId);   // 나를 팔로우한 사람 목록
+  List<FollowResponse> getFollowing(UUID userId);   // 내가 팔로우한 사람 목록
+  List<FollowResponse> getFollowers(UUID userId);   // 나를 팔로우한 사람 목록
   boolean isFollowing(UUID followerId, UUID followingId);
 }
 

--- a/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
@@ -8,13 +8,13 @@ import team03.mopl.common.exception.follow.AlreadyFollowingException;
 import team03.mopl.common.exception.follow.CantFollowSelfException;
 import team03.mopl.common.exception.follow.FollowNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.follow.dto.FollowResponse;
 import team03.mopl.domain.follow.entity.Follow;
 import team03.mopl.domain.follow.repository.FollowRepository;
 import team03.mopl.domain.notification.entity.NotificationType;
 import team03.mopl.domain.notification.service.NotificationService;
 import team03.mopl.domain.user.UserRepository;
 import team03.mopl.domain.user.User;
-import team03.mopl.domain.user.UserResponse;
 import team03.mopl.domain.user.UserService;
 
 @Service
@@ -58,16 +58,16 @@ public class FollowServiceImpl implements FollowService {
 
   //나의 팔로잉 목록
   @Override
-  public List<UserResponse> getFollowing(UUID userId) {
+  public List<FollowResponse> getFollowing(UUID userId) {
     List<UUID> list = followRepository.findAllByFollowerId(userId).stream().map(Follow::getFollowingId).toList();
-    return list.stream().map(userService::find).toList();
+    return list.stream().map( id -> FollowResponse.fromUserResponse(id, userService.find(id))).toList();
   }
 
   //나를 팔로우하는 사람들 목록
   @Override
-  public List<UserResponse> getFollowers(UUID userId) {
+  public List<FollowResponse> getFollowers(UUID userId) {
     List<UUID> list = followRepository.findAllByFollowingId(userId).stream().map(Follow::getFollowerId).toList();
-    return list.stream().map(userService::find).toList();
+    return list.stream().map(id -> FollowResponse.fromUserResponse(id, userService.find(id))).toList();
   }
 
   @Override

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -126,7 +126,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     return VideoSyncDto.builder()
         .videoControlAction(request.videoControlAction())
-        .currentTime(savedWatchRoom.getCurrentTime())
+        .currentTime(savedWatchRoom.getPlayTime())
         .isPlaying(savedWatchRoom.getIsPlaying())
         .build();
   }

--- a/src/test/java/team03/mopl/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/team03/mopl/domain/follow/controller/FollowControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import team03.mopl.domain.follow.dto.FollowRequest;
+import team03.mopl.domain.follow.dto.FollowResponse;
 import team03.mopl.domain.follow.service.FollowService;
 import team03.mopl.domain.user.UserResponse;
 
@@ -74,7 +75,7 @@ class FollowControllerTest {
   @WithMockUser(username = "testuser", roles = "USER")
   void testGetFollowing() throws Exception {
     UUID userId = UUID.randomUUID();
-    UserResponse user = new UserResponse("user1@example.com", "user1", "USER", false, null);
+    FollowResponse user = new FollowResponse( userId, "user1@example.com", "user1", "USER", null);
     when(followService.getFollowing(userId)).thenReturn(List.of(user));
 
     mockMvc.perform(get("/api/follows/{userId}/following", userId))
@@ -89,7 +90,7 @@ class FollowControllerTest {
   @WithMockUser(username = "testuser", roles = "USER")
   void testGetFollowers() throws Exception {
     UUID userId = UUID.randomUUID();
-    UserResponse user = new UserResponse("follower@example.com", "follower", "USER", false, null);
+    FollowResponse user = new FollowResponse( userId,"follower@example.com", "follower", "USER", null);
     when(followService.getFollowers(userId)).thenReturn(List.of(user));
 
     mockMvc.perform(get("/api/follows/{userId}/followers", userId))


### PR DESCRIPTION
## 🛰️ Issue Number

- 팔로워/팔로우 조회 시 user id가 없음
- id가 없어 팔로우 요청, 팔로우 취소, 플레이리스트 보기 등 기능을 만들기 어려워 id 필드를 추가하였습니다.

## 🪐 작업 내용
### FollowResponse DTO 추가
- FollowService 의 getFollowing(), getFollowers() 메서드 반환값 List<UserResponse>에서 List<FollowResponse> 로 변경
- 테스트 코드에도 DTO 적용

### 해당 내용 수정 후 프론트
- id 필드로 해당 유저의 상세 정보를 불러올 수 있게되었습니다.
- 팔로우 요청 및 팔로우 취소도 가능해졌습니다.

 (관리자로 로그인한 상태 - 플레이리스트는 더미입니다.)
![image](https://github.com/user-attachments/assets/3f66c364-2a11-4cc3-a1e4-4b8581f8b755)

(내 팔로우 목록에서 1233 유저의 프로필을 클릭해 상세 프로필 페이지로 이동) 
![image](https://github.com/user-attachments/assets/36e177a0-d3a6-4231-8840-5c7f4df971d8)

(팔로우 이전)
![image](https://github.com/user-attachments/assets/374d0200-ed9a-401d-aef7-59ea60f40ba7)

(팔로우 이후 - 현재 프론트엔드 언팔로우 기능 수정중)
![image](https://github.com/user-attachments/assets/5ca9757a-dc33-4cc3-86fe-c0d6acebfcf1)


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?