### PR TITLE
feat: 유저 프로필

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,8 @@ dependencies {
     testImplementation 'org.springframework:spring-websocket'
     testImplementation 'org.springframework:spring-messaging'
 
+    //S3
+    implementation 'software.amazon.awssdk:s3:2.31.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/team03/mopl/common/config/StorageConfig.java
+++ b/src/main/java/team03/mopl/common/config/StorageConfig.java
@@ -1,0 +1,29 @@
+package team03.mopl.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Component
+public class StorageConfig {
+
+  @Bean
+  @ConditionalOnProperty(name = "mopl.storage.type",havingValue = "s3")
+  public S3Client s3Client(
+      @Value("${mopl.storage.s3.access-key}") String accessKey,
+      @Value("${mopl.storage.s3.secret-key}") String secretKey,
+      @Value("${mopl.storage.s3.region}") String region
+  ) {
+    return S3Client.builder()
+        .region(Region.of(region))
+        .credentialsProvider(StaticCredentialsProvider.create(
+            AwsBasicCredentials.create(accessKey,secretKey)
+        ))
+        .build();
+  }
+}

--- a/src/main/java/team03/mopl/domain/user/User.java
+++ b/src/main/java/team03/mopl/domain/user/User.java
@@ -66,12 +66,15 @@ public class User {
   @Column(length = 255)
   private String profileImage;
 
-  public void update(String name, String password) {
+  public void update(String name, String password, String profileImage) {
     if (name != null && !name.equals(this.name)) {
       this.name = name;
     }
     if (password != null && !password.equals(this.password)) {
       this.password = password;
+    }
+    if (profileImage != null && !profileImage.equals(this.profileImage)) {
+      this.profileImage = profileImage;
     }
   }
 }

--- a/src/main/java/team03/mopl/domain/user/UserController.java
+++ b/src/main/java/team03/mopl/domain/user/UserController.java
@@ -3,15 +3,19 @@ package team03.mopl.domain.user;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
@@ -21,8 +25,8 @@ public class UserController {
   private final UserService userService;
   private final ProfileImageService profileImageService;
 
-  @PostMapping
-  public ResponseEntity<UserResponse> create(@RequestBody UserCreateRequest request) {
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<UserResponse> create(@ModelAttribute UserCreateRequest request) {
     return ResponseEntity.ok(userService.create(request));
   }
 
@@ -32,8 +36,10 @@ public class UserController {
   }
 
   @PutMapping("/{userId}")
-  public ResponseEntity<UserResponse> update(@PathVariable UUID userId, @RequestBody UserUpdateRequest request) {
-    return ResponseEntity.ok(userService.update(userId,request));
+  public ResponseEntity<UserResponse> update(@PathVariable UUID userId,
+      @RequestPart UserUpdateRequest request,
+      @RequestPart(value = "profile", required = false) MultipartFile profile) {
+    return ResponseEntity.ok(userService.update(userId,request,profile));
   }
 
   @DeleteMapping("/{userId}")

--- a/src/main/java/team03/mopl/domain/user/UserCreateRequest.java
+++ b/src/main/java/team03/mopl/domain/user/UserCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UserCreateRequest(
     @NotBlank(message = "이메일은 필수입니다.")
@@ -19,7 +20,8 @@ public record UserCreateRequest(
     //@Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).{8,}$",
     //    message = "비밀번호는 최소 8자 이상, 숫자, 문자, 특수문자를 포함해야 합니다")
     String password,
-    String profileImage// /static/profile/woody.png
+    //String profileImage// /static/profile/woody.png
+    MultipartFile profile
 ) {
 
 }

--- a/src/main/java/team03/mopl/domain/user/UserService.java
+++ b/src/main/java/team03/mopl/domain/user/UserService.java
@@ -2,13 +2,14 @@ package team03.mopl.domain.user;
 
 import java.util.List;
 import java.util.UUID;
+import org.springframework.web.multipart.MultipartFile;
 import team03.mopl.domain.oauth2.GoogleUserInfo;
 import team03.mopl.domain.oauth2.KakaoUserInfo;
 
 public interface UserService {
   UserResponse create(UserCreateRequest request);
   UserResponse find(UUID userId);
-  UserResponse update(UUID userId, UserUpdateRequest request);
+  UserResponse update(UUID userId, UserUpdateRequest request, MultipartFile profile);
   void delete(UUID userId);
   List<UserResponse> findAll();
   User loginOrRegisterOAuth(String email,String name);

--- a/src/main/java/team03/mopl/domain/user/UserServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/user/UserServiceImpl.java
@@ -2,18 +2,18 @@ package team03.mopl.domain.user;
 
 import static team03.mopl.domain.user.Role.*;
 
+import jakarta.annotation.PostConstruct;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 import team03.mopl.common.exception.user.DuplicatedEmailException;
 import team03.mopl.common.exception.user.DuplicatedNameException;
 import team03.mopl.common.exception.user.UserNotFoundException;
-import team03.mopl.domain.oauth2.GoogleUserInfo;
-import team03.mopl.domain.oauth2.KakaoUserInfo;
+import team03.mopl.storage.ProfileImageStorage;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +22,12 @@ public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
+  private final ProfileImageStorage profileImageStorage;
+
+  @PostConstruct
+  public void logStorageType() {
+    log.info("ProfileImageStorage : {}", profileImageStorage.getClass().getSimpleName());
+  }
 
   @Override
   public UserResponse create(UserCreateRequest request) {
@@ -31,6 +37,14 @@ public class UserServiceImpl implements UserService {
     if (userRepository.existsByName(request.name())){
       throw new DuplicatedNameException();
     }
+
+    String uploadedImageUrl = null;
+    if (request.profile() != null && !request.profile().isEmpty()){
+      uploadedImageUrl = profileImageStorage.upload(request.profile());
+    }else{
+      uploadedImageUrl = "/static/profile/woody.png"; //기본 이미지
+    }
+
     User user = User.builder()
         .name(request.name())
         .email(request.email())
@@ -38,7 +52,7 @@ public class UserServiceImpl implements UserService {
         .role(USER)
         .isLocked(false)
         .isTempPassword(false)
-        .profileImage(request.profileImage())
+        .profileImage(uploadedImageUrl)
         .build();
     return UserResponse.from(userRepository.save(user));
   }
@@ -50,13 +64,27 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
-  public UserResponse update(UUID userId, UserUpdateRequest request) {
+  public UserResponse update(UUID userId, UserUpdateRequest request, MultipartFile profile) {
     User user= userRepository.findById(userId)
         .orElseThrow(UserNotFoundException::new);
-    if(request.newPassword()!=null) {
-      String encodedPassword = passwordEncoder.encode(request.newPassword());
-      user.update(request.newName(),encodedPassword);
+
+    String encodedPassword = null;
+    if(request.newPassword() != null){
+      encodedPassword = passwordEncoder.encode(request.newPassword());
     }
+
+    String newImageUrl = null;
+    if(profile != null && !profile.isEmpty()){
+      if(user.getProfileImage() != null && !user.getProfileImage().startsWith("/static/profile")){
+        profileImageStorage.delete(user.getProfileImage());
+      }
+      newImageUrl = profileImageStorage.upload(profile);
+    }else{
+      newImageUrl = user.getProfileImage();
+    }
+
+    user.update(request.newName(), encodedPassword, newImageUrl);
+
     return UserResponse.from(user);
   }
 

--- a/src/main/java/team03/mopl/domain/user/UserUpdateRequest.java
+++ b/src/main/java/team03/mopl/domain/user/UserUpdateRequest.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.user;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UserUpdateRequest(
     @Size(min = 1, max = 20,message = "1글자 이상 20자 이하입니다.")
@@ -10,6 +11,7 @@ public record UserUpdateRequest(
     //@Size(min = 8, max = 60, message = "비밀번호는 8자이상 60자 이하입니다.")
     //@Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&*]).{8,}$",
     //    message = "비밀번호는 최소 8자 이상, 숫자, 문자, 특수문자를 포함해야 합니다")
-    String newPassword)
+    String newPassword
+)
 {
 }

--- a/src/main/java/team03/mopl/storage/LocalProfileStorage.java
+++ b/src/main/java/team03/mopl/storage/LocalProfileStorage.java
@@ -1,0 +1,54 @@
+package team03.mopl.storage;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@ConditionalOnProperty(name = "mopl.storage.type",havingValue = "local",matchIfMissing = true)
+@RequiredArgsConstructor
+public class LocalProfileStorage implements ProfileImageStorage{
+
+  @Value("${mopl.storage.local.root-path}")
+  private String rootPath;
+
+  private Path reslovedRootPath;
+
+  @PostConstruct
+  public void init() throws IOException {
+    reslovedRootPath = Paths.get(rootPath).toAbsolutePath().normalize();
+    Files.createDirectories(reslovedRootPath);
+  }
+
+  @Override
+  public String upload(MultipartFile file) {
+    try{
+      String fileName = UUID.randomUUID()+"_"+file.getOriginalFilename();
+      Path targetPath = reslovedRootPath.resolve(fileName);
+      file.transferTo(targetPath.toFile());
+      return "/local/profile/" + fileName;
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new RuntimeException("local 이미지 저장 실패",e);
+    }
+  }
+
+  @Override
+  public void delete(String profileImage) {
+    try{
+      String fileName = Paths.get(profileImage).getFileName().toString();
+      Path path = Paths.get(rootPath).resolve(fileName);
+      Files.deleteIfExists(path);
+    } catch (IOException e) {
+      throw new RuntimeException("이미지 삭제 실패",e);
+    }
+  }
+}

--- a/src/main/java/team03/mopl/storage/ProfileImageStorage.java
+++ b/src/main/java/team03/mopl/storage/ProfileImageStorage.java
@@ -1,0 +1,9 @@
+package team03.mopl.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileImageStorage {
+  String upload(MultipartFile file);
+
+  void delete(String profileImage);
+}

--- a/src/main/java/team03/mopl/storage/S3ProfileStorage.java
+++ b/src/main/java/team03/mopl/storage/S3ProfileStorage.java
@@ -1,0 +1,52 @@
+package team03.mopl.storage;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@ConditionalOnProperty(name = "mopl.storage.type",havingValue = "s3")
+@RequiredArgsConstructor
+public class S3ProfileStorage implements ProfileImageStorage{
+
+  @Value("${mopl.storage.s3.bucket}")
+  private String bucket;
+
+  private final S3Client s3Client;
+
+  @Override
+  public String upload(MultipartFile file) {
+    String fileName = UUID.randomUUID()+"_"+file.getOriginalFilename();
+    try{
+      s3Client.putObject(
+          PutObjectRequest.builder()
+              .bucket(bucket)
+              .key(fileName)
+              .contentType(file.getContentType())
+              .build(),
+          software.amazon.awssdk.core.sync.RequestBody.fromInputStream(file.getInputStream(),
+              file.getSize())
+      );
+    } catch (IOException e) {
+      throw new RuntimeException("s3 업로드 실패",e);
+    }
+    return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(fileName)).toExternalForm();
+  }
+
+  @Override
+  public void delete(String profileImage) {
+    try{
+      String key = URI.create(profileImage).getPath().substring(1);
+      s3Client.deleteObject(builder -> builder.bucket(bucket).key(key));
+    }catch (Exception e) {
+      throw new RuntimeException("이미지 삭제 실패",e);
+    }
+  }
+}

--- a/src/test/java/team03/mopl/domain/user/UserControllerTest.java
+++ b/src/test/java/team03/mopl/domain/user/UserControllerTest.java
@@ -15,10 +15,12 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @WebMvcTest(UserController.class)
@@ -40,14 +42,14 @@ class UserControllerTest {
   @Test
   void create() throws Exception {
     UserCreateRequest request = new UserCreateRequest("홍길동", "hong@naver.com", "password",
-        "profile.png");
-    UserResponse response = new UserResponse("hong@naver.com", "홍길동", "user", false, "profile.png");
+        null);
+    UserResponse response = new UserResponse("hong@naver.com", "홍길동", "user", false, null);
 
     when(userService.create(any(UserCreateRequest.class))).thenReturn(response);
 
     mockMvc.perform(post("/api/users")
             .with(csrf())
-            .contentType(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
             .content(objectMapper.writeValueAsString(request)))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.name").value("홍길동"))
@@ -55,6 +57,33 @@ class UserControllerTest {
         .andExpect(jsonPath("$.role").value("user"))
         .andExpect(jsonPath("$.isLocked").value(false));
   }
+
+  @WithMockUser
+  @Test
+  void create_with_profile() throws Exception {
+    MockMultipartFile profile = new MockMultipartFile(
+        "profile", "profile.png", "image/png", "dummy".getBytes());
+
+    MockMultipartFile jsonPart = new MockMultipartFile(
+        "request", "", "application/json",
+        objectMapper.writeValueAsBytes(
+            new UserCreateRequest("홍길동", "hong@naver.com", "password", null)
+        ));
+
+    UserResponse response = new UserResponse("hong@naver.com", "홍길동", "user", false, "profile.png");
+
+    when(userService.create(any(UserCreateRequest.class))).thenReturn(response);
+
+    mockMvc.perform(multipart("/api/users")
+            .file(profile)
+            .file(jsonPart)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("홍길동"))
+        .andExpect(jsonPath("$.email").value("hong@naver.com"));
+  }
+
 
   @WithMockUser
   @Test
@@ -72,7 +101,7 @@ class UserControllerTest {
         .andExpect(jsonPath("$.isLocked").value(false));
   }
 
-  @WithMockUser
+  /*@WithMockUser
   @Test
   void update() throws Exception {
     UUID userId = UUID.randomUUID();
@@ -88,6 +117,35 @@ class UserControllerTest {
             .with(csrf()))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.name").value("강감찬"));
+  }*/
+
+  @WithMockUser
+  @Test
+  void update_with_profile() throws Exception {
+    UUID userId = UUID.randomUUID();
+
+    MockMultipartFile profile = new MockMultipartFile(
+        "profile", "profile2.png", "image/png", "image-data".getBytes());
+    MockMultipartFile jsonPart = new MockMultipartFile(
+        "request", "", "application/json",
+        objectMapper.writeValueAsBytes(new UserUpdateRequest("강감찬", "newPass123")));
+
+    UserResponse response = new UserResponse("hong@naver.com", "강감찬", "user", false, "profile2.png");
+
+    when(userService.update(Mockito.eq(userId), any(UserUpdateRequest.class), any(MultipartFile.class)))
+        .thenReturn(response);
+
+    mockMvc.perform(multipart("/api/users/" + userId)
+            .file(profile)
+            .file(jsonPart)
+            .with(csrf())
+            .with(request -> {
+              request.setMethod("PUT");
+              return request;
+            }))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("강감찬"))
+        .andExpect(jsonPath("$.profileImage").value("profile2.png"));
   }
 
   @WithMockUser


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->
- #81 
## 🪐 작업 내용
<!-- 예시
- Interest 생성(Create) 기능
  - 유사도 계산하여 유사도가 80%미만인 경우에만 등록 가능하도록 구현
  - 테스트 코드 추가
- 관심사 삭제 기능 추가
  - 기본적인 삭제 구현
  - 테스트 코드 추가
 -->
1. **회원가입 시 (`POST /api/users`)**
    - `@ModelAttribute UserCreateRequest`로 JSON + Multipart 통합 처리
    - 기본 프로필 이미지가 없을 경우 `"/static/profile/woody.png"` 사용
    - `profileImageStorage` 전략에 따라 로컬 또는 S3에 저장
    - 저장된 URL을 DB에 저장
2. **회원 정보 수정 시 (`PUT /api/users/{userId}`)**
    - `@RequestPart UserUpdateRequest` + `@RequestPart MultipartFile profile` 방식으로 받음
    - 프로필 이미지가 있을 경우 기존 이미지 삭제 후 새로 업로드
    - `User.update()` 메서드에서 name, password, profileImage 수정


구분 | 회원가입 (@ModelAttribute) | 수정 (@RequestPart)
-- | -- | --
사용 어노테이션 | @ModelAttribute UserCreateRequest request | @RequestPart("request") UserUpdateRequest request
프로필 이미지 | @ModelAttribute가 DTO 내 MultipartFile 자동 바인딩 | DTO에 넣지 않고, 별도 @RequestPart("profile")로 전달
요청 형식 | multipart/form-data 폼데이터로 전송 | multipart/form-data + JSON 문자열 별도 파트로 전송
Postman에서의 입력 | 키=이름/이메일/비번/프로필 직접 입력 | request = JSON 문자열, profile = 파일
장점 | 간단한 폼 구조에서 직관적 (ex. 회원가입 폼 제출) | 구조가 명확함 (JSON 데이터와 파일 분리 가능)
DTO 구성 | MultipartFile profile 포함 | DTO는 파일 포함 X (파일은 컨트롤러에서 MultipartFile로 받음)

- `@ModelAttribute`: form 기반 입력에 적합. 간단한 구조에서 활용.
- `@RequestPart`: JSON + 파일을 분리해서 받고 싶을 때 적합. API 구조 분명.

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?