### PR TITLE
docs: content 조회 시의 파라미터들 Swagger에서 각각 입력할 수 있도록 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/content/controller/ContentController.java
+++ b/src/main/java/team03/mopl/domain/content/controller/ContentController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -40,7 +41,7 @@ public class ContentController {
 
   @GetMapping
   public ResponseEntity<CursorPageResponseDto<ContentDto>> getAll(
-      @Valid @ModelAttribute ContentSearchRequest contentSearchRequest
+      @Valid @ParameterObject @ModelAttribute ContentSearchRequest contentSearchRequest
   ) {
     return ResponseEntity.ok(contentService.getCursorPage(contentSearchRequest));
   }

--- a/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
+++ b/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
@@ -23,7 +23,7 @@ public class ContentSearchRequest {
   private String title;
 
   @AllowedValues(enumClass = ContentType.class, message = "contentType은 MOVIE, TV, SPORTS 중 하나여야 합니다.")
-  private String ContentType;
+  private String contentType = "MOVIE";
 
   @AllowedValues(enumClass = SortBy.class, message = "sortBy는 TITLE, RELEASE_AT 중 하나여야 합니다.")
   private String sortBy = "TITLE";

--- a/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
+++ b/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
@@ -1,11 +1,13 @@
 package team03.mopl.domain.content.dto;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import team03.mopl.domain.content.ContentType;
 import team03.mopl.domain.content.SortBy;
 import team03.mopl.domain.content.SortDirection;
@@ -20,20 +22,26 @@ import team03.mopl.domain.content.validation.AllowedValues;
 @NoArgsConstructor // @ModelAttribute 가 바인딩할 때 요구하는 생성자
 public class ContentSearchRequest {
 
+  @Parameter
   private String title;
 
+  @Parameter
   @AllowedValues(enumClass = ContentType.class, message = "contentType은 MOVIE, TV, SPORTS 중 하나여야 합니다.")
   private String contentType = "MOVIE";
 
+  @Parameter
   @AllowedValues(enumClass = SortBy.class, message = "sortBy는 TITLE, RELEASE_AT 중 하나여야 합니다.")
   private String sortBy = "TITLE";
 
+  @Parameter
   @AllowedValues(enumClass = SortDirection.class, message = "direction은 DESC, ASC 중 하나여야 합니다.")
   private String direction = "DESC";
 
+  @Parameter
   @Pattern(regexp = "^[A-Za-z0-9-_]+={0,2}$", message = "cursor는 Base64 형식 문자열이여야 합니다.")
   private String cursor;
 
+  @Parameter
   @Min(value = 1, message = "조회하는 컨텐츠 데이터 개수는 최소 1개 이상이어야 합니다.")
   @Max(value = 50, message = "조회하는 컨텐츠 데이터 개수가 최대 50개를 넘을 수 없습니다.")
   private int size = 20;

--- a/src/main/java/team03/mopl/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/team03/mopl/domain/review/dto/ReviewResponse.java
@@ -1,16 +1,25 @@
 package team03.mopl.domain.review.dto;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 import team03.mopl.domain.review.entity.Review;
 
 public record ReviewResponse(
+    UUID id,
+    UUID authorId,
+    String authorName,
     String title,
     String comment,
     BigDecimal rating
 ) {
 
   public static ReviewResponse from(Review review) {
-    return new ReviewResponse(review.getTitle(),
-        review.getComment(), review.getRating());
+    return new ReviewResponse(
+        review.getId(),
+        review.getUser().getId(),
+        review.getUser().getName(),
+        review.getTitle(),
+        review.getComment(),
+        review.getRating());
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

- ModelAttribute 사용 시 Swagger에서 파라미터 별로 입력 변경하여 테스트할 수 없었음(JSON 형태로 전송해야함)
- 이에 따라 파라미터별 설명이나 데이터 타입 명시가 불가능

## 🪐 작업 내용

- 적용한 것:  @ParameterObject, @Parameter
- 결과:
![image](https://github.com/user-attachments/assets/7c9fa9a5-990b-4f0e-911e-7a2dbe21c2bc)



## 📚 Reference
- [[SpringDoc] 쿼리 파라미터가 이상하다?](https://yeonyeon.tistory.com/324)


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?