### PR TITLE
Chore: CD 워크 플로우 작성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,161 @@
+# main 브랜치에 push되면 main 브랜치에서 워크 플로우 실행
+on:
+  push:
+    branches:
+      - main
+
+
+# 새 워크플로우 시작시 이전 워크 플로우 취소
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: true
+
+# 환경변수 - ${{ vars.xxx }} = GitHub 환경 변수
+env:
+  AWS_ACCOUNT_ID: ${{ vars.AWS_ACCOUNT_ID }}
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  CONTAINER_NAME: ${{ vars.CONTAINER_NAME }}
+  ECR_REPOSITORY_URI: ${{ vars.ECR_REPOSITORY_URI }}
+  ECS_CLUSTER: ${{ vars.ECS_CLUSTER }}
+  ECS_SERVICE: ${{ vars.ECS_SERVICE }}
+
+jobs:
+  # 코드 체크아웃 → Java 세팅 → 테스트
+  test:
+    name: 배포 전 테스트 수행
+    runs-on: ubuntu-latest
+    # PostgreSQL 테스트용 서비스 컨테이너 설정
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: testuser
+          POSTGRES_PASSWORD: testpass
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 3
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@4
+        with:
+          fetch-depth: 0
+
+      - name: 마지막 커밋 확인
+        run: git log -1 --name-status
+
+      - name: JDK setup
+        uses: actions/setup-java@4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: gradlew 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 테스트 수행
+        env:
+          SPRING_PROFILES_ACTIVE: ci
+          SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/testdb
+          SPRING_DATASOURCE_USERNAME: testuser
+          SPRING_DATASOURCE_PASSWORD: testpass
+        run: ./gradlew test
+
+  push_and_deploy:
+    name: 이미지 빌드 및 푸시 그리고 ECS를 통한 배포
+    needs: test
+    runs-on: ubuntu-latest
+
+    # OIDC 권한
+    permissions:
+      # GitHub Actions의 OIDC 토큰 발급
+      id-token: write
+      contents: read
+
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@4
+
+      - name: AWS 자격 증명(OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # 이 역할의 권한으로 AWS 작업 수행
+          role-to-assume: arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/GitHubActionsRole
+          # 리소스들의 리전
+          aws-region: ${{ env.AWS_REGION }}
+
+      # 1. 이미지 빌드 및 푸시
+      - name: Public ECR 로그인
+        # 도메인에 로그인
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker 이미지 빌드 및 푸시
+        uses: docker/build-push-action@v6
+        with:
+          # DockerFIle 기준으로 빌드
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ env.ECR_REPOSITORY_URI }}:latest
+            ${{ env.ECR_REPOSITORY_URI }}:${{ github.sha }}
+          # 깃헙 액션 저장소에 저장해 둔 Docker build 캐시 불러오기
+          cache-from: type=gha
+          # 깃헙 액션 저장소에 캐시를 최대한 많이 저장하기
+          cache-to: type=gha, mode=max
+
+      # 2. ECS를 통한 배포
+      - name: ECS 태스크 정의 실행
+        # 해당 스텝의 고유 이름을 render-task-def 로 지정한다
+        # 다른 스텝에서 이 스텝의 결과값(outputs)을 참조할 수 있게 된다.
+        id: render-task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          # a. 원본 설계도 파일
+          task-definition: ecs/task-definition.json
+          # b. (설계도 파일의 name 속성 값 = 지정한 컨테이너 이름)인 컨테이너 찾기
+          container-name: ${{ env.CONTAINER_NAME }}
+          # c. image 속성 값을 새로 빌드한 이미지로 동적으로 덮어씌웁니다.
+          image: ${{ env.ECR_REPOSITORY_URI }}:${{ github.sha }}
+
+      # AWS EC2 기본 배포 전략: 롤링 업데이트 이용해보겠습니다.
+      #      - name: 실행 중인 태스크 중지
+      #        run: |
+      #          aws ecs update-service \
+      #            --cluster ${{ vars.ECS_CLUSTER }} \
+      #            --service ${{ vars.ECS_SERVICE }} \
+      #            --desired-count 0 \
+      #            --region ${{ vars.AWS_REGION }}
+
+      - name: ECS 서비스 배포
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render-task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          # 배포 후 서비스 안정 상태까지 대기
+          wait-for-service-stability: true
+          # 기존 이미지와 같아도 새로 배포 강제
+          force-new-deployment: true
+          # 배포 후 태스크 1개 실행
+          desired-count: 1
+
+
+
+
+
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,12 @@ jobs:
     # Kafka, Redis 사용시 서비스 컨테이너 추가될 예정
 
     steps:
-      - name: Checkout code
+      - name: 코드 체크아웃
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Show latest commit
+      - name: 마지막 커밋 확인
         run: git log -1 --name-status
 
       - name: JDK setup
@@ -43,7 +43,7 @@ jobs:
           java-version: '17'
           cache: gradle
       
-      - name: gradlew 권한 부여
+      - name: gradlew 실행 권한 부여
         run: chmod +x gradlew
         
       - name: 테스트 수행

--- a/.gitignore
+++ b/.gitignore
@@ -210,11 +210,11 @@ $RECYCLE.BIN/
 # .yaml
 **/application.yaml
 **/application-dev.yaml
-**/application-prod.yaml
 **/application-test.yaml
 
 # 환경변수
 .env
+mopl.env
 
 # build
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,7 @@ RUN ./gradlew build -x test
 FROM eclipse-temurin:17-jre AS runtime
 WORKDIR /app
 
+EXPOSE 8080
+
 COPY --from=build /app/build/libs/*.jar app.jar
 CMD ["java", "-jar", "app.jar"]

--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -1,0 +1,67 @@
+{
+  "taskDefinitionArn": "arn:aws:ecs:ap-northeast-2:112555930244:task-definition/mopl-app-task:2",
+  "containerDefinitions": [
+    {
+      "name": "mopl-container",
+      "image": "public.ecr.aws/k5f2z7e1/mopl-app",
+      "cpu": 256,
+      "memory": 512,
+      "memoryReservation": 256,
+      "portMappings": [
+        {
+          "name": "mopl-container-80-tcp",
+          "containerPort": 8080,
+          "hostPort": 80,
+          "protocol": "tcp",
+          "appProtocol": "http"
+        }
+      ],
+      "essential": true,
+      "environment": [],
+      "environmentFiles": [
+        {
+          "value": "arn:aws:s3:::mopl-03-bucket/mopl.env",
+          "type": "s3"
+        }
+      ],
+      "mountPoints": [],
+      "volumesFrom": [],
+      "ulimits": [],
+      "systemControls": []
+    }
+  ],
+  "family": "mopl-app-task",
+  "executionRoleArn": "arn:aws:iam::112555930244:role/ecsTaskExecutionRole",
+  "networkMode": "bridge",
+  "revision": 2,
+  "volumes": [],
+  "status": "ACTIVE",
+  "requiresAttributes": [
+    {
+      "name": "ecs.capability.env-files.s3"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.21"
+    },
+    {
+      "name": "com.amazonaws.ecs.capability.docker-remote-api.1.18"
+    }
+  ],
+  "placementConstraints": [],
+  "compatibilities": [
+    "EC2"
+  ],
+  "requiresCompatibilities": [
+    "EC2"
+  ],
+  "cpu": "256",
+  "memory": "512",
+  "runtimePlatform": {
+    "cpuArchitecture": "X86_64",
+    "operatingSystemFamily": "LINUX"
+  },
+  "registeredAt": "2025-07-09T13:25:00.041Z",
+  "registeredBy": "arn:aws:iam::112555930244:user/zerone",
+  "enableFaultInjection": false,
+  "tags": []
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,0 +1,101 @@
+mopl:
+  storage:
+    type: ${STORAGE_TYPE:local}
+    local:
+      root-path: ${STORAGE_LOCAL_ROOT_PATH:.mopl/storage}
+    s3:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+      region: ${AWS_S3_REGION}
+      bucket: ${AWS_S3_BUCKET}
+      presigned-url-expiration: ${AWS_S3_PRESIGNED_URL_EXPIRATION:600}
+
+frontend:
+  redirect-uri: http://${AWS_ALB_DNS_UR}/oauth/callback
+
+
+spring:
+  application:
+    name: mopl
+  datasource:
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
+
+  batch:
+    jdbc:
+      initialize-schema: never
+    job:
+      enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        highlight_sql: false
+    open-in-view: false
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            # 로드 밸런서 DNS 주소로 변경
+            redirect-uri: "http://${AWS_ALB_DNS_UR}/api/oauth2/callback/google"
+            scope:
+              - profile
+              - email
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            # 로드 밸런서 DNS 주소로 변경
+            redirect-uri: "http://${AWS_ALB_DNS_UR}/api/oauth2/callback/kakao"
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 900000
+  refresh-token-expiration: 604800000
+
+auth:
+  temp-password-expiration: 30
+
+admin:
+  email: ${ADMIN_EMAIL}
+  password: ${ADMIN_PASSWORD}
+
+sports:
+  baseurl: https://www.thesportsdb.com/api/v1/json
+tmdb:
+  baseurl: https://api.themoviedb.org/3
+  api_token: ${TMDB_API_TOKEN}
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## 🛰️ Issue Number

- #84 

## 🪐 작업 내용

**<아키텍처 구성>**
1. 소스 코드: GitHub Repository
2. CI/CD: GitHub Actions
    - main 브랜치 Push 시 CD(빌드, 배포) 파이프라인 자동 실행
3. 컨테이너 이미지 저장소: Amazon ECR
    - GitHub Actions에서 빌드된 Docker 이미지를 버전별로 저장
4. 보안 및 인증: AWS IAM
    - GitHub Actions와 AWS 간의 안전한 인증을 위해 OIDC(OpenID Connect) 방식 사용
5. 네트워크 관문: Amazon ALB
    - 인터넷 사용자의 HTTP:80 트래픽을 수신하는 단일 진입점 역할
    - 고정된 DNS 주소를 제공하여 안정적인 서비스 엔드포인트 역할 수행
        - localhost:8080 을 대체하기 위해 도입
6. 컴퓨팅 및 배포: Amazon ECS on EC2
    - ECS: 컨테이너 오케스트레이션 및 배포 자동화 관리
    - EC2: t2.micro 인스턴스 1대가 실제 Docker 컨테이너를 실행
7. 데이터베이스: Amazon RDS (Relational Database Service)
    - PostgreSQL 데이터베이스
8. 네트워크 보안: Amazon VPC
    - 보안 그룹:
        - ALB → EC2 (80 포트) 로의 트래픽만 허용
        - EC2 → RDS (5432 포트) 로의 트래픽만 허용

------

**이슈에 적었던 것에서 달라진 부분은 ALB(로드밸런서) 도입입니다!**

application.yaml에 이런 url(http://localhost:8080/api/oauth2/callback/google)이 있다. 운영 환경에서는 localhost:8080에 EC2 인스턴스의 공인 IP 주소를 넣어야 한다.
1. EC2 인스턴스의 IP는 가변적이다. → 바뀔 때마다 수정해야 한다. 영원히 띄워두면 좋겠지만, 현재는 “진짜 운영 환경”이 아니기 때문에
2. 현재는 AWS 환경 세팅만 해놨기 때문에 EC2가 정지되어 있다. (→ 이 부분은 오토 스케일링 수정해서 실행시켜 놨다)

URL을 어떻게 고정해볼까 하다가 로드밸런서 도입해서 URL을 고정했습니다.

**<ELB 요금 정책 확인>**
https://aws.amazon.com/ko/elasticloadbalancing/pricing/
- Classic 및 Application Load Balancer → 통일해서 월별 750시간
    → 지금부터 한 달 띄워도 22*24= 약 528

**<해야함: RDS에 테이블 만들기>**
테이블 생성은 아직 해놓진 않았습니다.
나중에 테이블 생성할 때는 RDS 보안 그룹에 컴퓨터 IP도 임시로 허용해놓고 접속해 테이블 만들면 될 것 같습니다! 

------

과연... 될까요? 우선 생각해놨던 부분은 다 해놨는데,

목요일에는 멘토님께 돌아가는 것처럼 보이는? 애플리케이션을 내놓는 게 일순위이니, 만약 한번에 작동하지 않는다면 차라리 애플리케이션이 원활히 잘 돌아가게 하는 것을 목표로 하고, 오늘 말했던대로 Railway나 EC2에 배포해서 동작 확인을 먼저 하는 게 나을 수도 있겠다는 생각이 듭니다.


## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?