### PR TITLE
fix: watchRoom ownerId 필드를 User객체로 변경

### DIFF
--- a/src/main/java/team03/mopl/domain/watchroom/controller/WatchRoomController.java
+++ b/src/main/java/team03/mopl/domain/watchroom/controller/WatchRoomController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team03.mopl.domain.watchroom.dto.WatchRoomCreateRequest;
 import team03.mopl.domain.watchroom.dto.WatchRoomDto;
 import team03.mopl.domain.watchroom.service.WatchRoomService;
+import team03.mopl.jwt.CustomUserDetails;
 
 @RestController
 @RequestMapping("/api/rooms")
@@ -34,7 +36,8 @@ public class WatchRoomController {
   }
 
   @PostMapping
-  public ResponseEntity<WatchRoomDto> createChatRoom(@RequestBody WatchRoomCreateRequest request) {
+  public ResponseEntity<WatchRoomDto> createChatRoom(@RequestBody WatchRoomCreateRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
     return ResponseEntity.status(HttpStatus.CREATED).body(watchRoomService.create(request));
   }
 }

--- a/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomCreateRequest.java
+++ b/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomCreateRequest.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.watchroom.dto;
 
 import java.util.UUID;
 
+//todo - @AuthenticationPrincipal 적용으로 수정
 public record WatchRoomCreateRequest(
   UUID contentId,
   UUID ownerId

--- a/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomDto.java
+++ b/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomDto.java
@@ -1,5 +1,6 @@
 package team03.mopl.domain.watchroom.dto;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import team03.mopl.domain.watchroom.entity.WatchRoom;
 
@@ -9,6 +10,8 @@ public record WatchRoomDto(
     UUID id,
     String contentTitle,
     UUID ownerId,
+    String ownerName,
+    LocalDateTime createdAt,
     Long headCount
 
 ) {
@@ -17,7 +20,9 @@ public record WatchRoomDto(
     return new WatchRoomDto(
         watchRoom.getId(),
         watchRoom.getContent().getTitle(),
-        watchRoom.getOwnerId(),
+        watchRoom.getOwner().getId(),
+        watchRoom.getOwner().getName(),
+        watchRoom.getCreatedAt(),
         headcount
     );
   }
@@ -26,7 +31,9 @@ public record WatchRoomDto(
     return new WatchRoomDto(
         watchRoomContentWithHeadcountDto.getWatchRoom().getId(),
         watchRoomContentWithHeadcountDto.getContent().getTitle(),
-        watchRoomContentWithHeadcountDto.getWatchRoom().getOwnerId(),
+        watchRoomContentWithHeadcountDto.getWatchRoom().getOwner().getId(),
+        watchRoomContentWithHeadcountDto.getWatchRoom().getOwner().getName(),
+        watchRoomContentWithHeadcountDto.getWatchRoom().getCreatedAt(),
         watchRoomContentWithHeadcountDto.getHeadCount()
     );
   }

--- a/src/main/java/team03/mopl/domain/watchroom/entity/WatchRoom.java
+++ b/src/main/java/team03/mopl/domain/watchroom/entity/WatchRoom.java
@@ -3,6 +3,7 @@ package team03.mopl.domain.watchroom.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.user.User;
 
 
 @Entity
@@ -35,8 +37,9 @@ public class WatchRoom {
   @GeneratedValue(strategy = GenerationType.AUTO)
   private UUID id;
 
-  @Column(name = "owner_id", nullable = false)
-  private UUID ownerId;
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "owner_id", nullable = false)
+  private User owner;
 
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
@@ -91,12 +94,12 @@ public class WatchRoom {
   }
 
   //방장 변경
-  public void changeOwner(UUID newOwnerId) {
-    this.ownerId = newOwnerId;
+  public void changeOwner(User newOwner) {
+    this.owner = newOwner;
   }
 
   //방장인지 확인
   public boolean isOwner(UUID userId) {
-    return this.ownerId.equals(userId);
+    return this.owner.equals(userId);
   }
 }

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -17,7 +17,6 @@ import team03.mopl.domain.watchroom.dto.VideoSyncDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomInfoDto;
 import team03.mopl.domain.watchroom.entity.WatchRoom;
 import team03.mopl.domain.watchroom.entity.WatchRoomParticipant;
-import team03.mopl.domain.watchroom.exception.AlreadyJoinedWatchRoomRoomException;
 import team03.mopl.domain.watchroom.exception.WatchRoomRoomNotFoundException;
 import team03.mopl.domain.watchroom.repository.WatchRoomParticipantRepository;
 import team03.mopl.domain.watchroom.repository.WatchRoomRepository;
@@ -46,7 +45,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
         ContentNotFoundException::new);
 
     WatchRoom watchRoom = WatchRoom.builder()
-        .ownerId(owner.getId())
+        .owner(owner)
         .content(content)
         .build();
 
@@ -111,7 +110,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
     User user = userRepository.findByEmail(username).orElseThrow(UserNotFoundException::new);
 
     //방장이 아니라면 제어 권한 없음
-    if(!watchRoom.getOwnerId().equals(user.getId())) {
+    if(!watchRoom.getOwner().equals(user.getId())) {
       throw new IllegalArgumentException("방장이 아님");
     }
 
@@ -189,7 +188,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
             null,
             //todo - 프로필 필드 추가 시 변경
             //participant.getUser().getProfile(),
-            participant.getUser().getId().equals(watchRoom.getOwnerId()))).toList();
+            participant.getUser().getId().equals(watchRoom.getOwner()))).toList();
 
     return ParticipantsInfoDto.builder()
         .participantDtoList(participantList)


### PR DESCRIPTION
## 🛰️ Issue Number
- 시청방 조회시 방장 이름을 보여주기 위해 id필드 뿐만 아니라 name 필드도 필요해짐.


## 🪐 작업 내용
- watchRoom ownerId 필드를 User객체 Owner로 변경
- watchRoomDto에 ownerName 필드, createdAt 추가

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요? 
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?