### PR TITLE
refactor: keyword delete 메서드에 @AuthenticationPrincipal 추가

### DIFF
--- a/src/main/java/team03/mopl/common/exception/ErrorCode.java
+++ b/src/main/java/team03/mopl/common/exception/ErrorCode.java
@@ -27,8 +27,8 @@ public enum ErrorCode {
   //Notification
   NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "존재하지 않는 알림입니다."),
 
-  KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD_001", "해당 사용자의 키워드를 찾을 수 없습니다.");
-
+  KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD_001", "해당 사용자의 키워드를 찾을 수 없습니다."),
+  KEYWORD_DELETE_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "KEYWORD_002", "본인의 키워드만 삭제할 수 있습니다.");
 
   private HttpStatus status;
   // 추적하기 쉽도록하는 필드

--- a/src/main/java/team03/mopl/common/exception/curation/KeywordDeleteDeniedException.java
+++ b/src/main/java/team03/mopl/common/exception/curation/KeywordDeleteDeniedException.java
@@ -1,0 +1,18 @@
+package team03.mopl.common.exception.curation;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class KeywordDeleteDeniedException extends CurationException {
+  public KeywordDeleteDeniedException() {
+    super(ErrorCode.KEYWORD_DELETE_DENIED_EXCEPTION);
+  }
+
+  public KeywordDeleteDeniedException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public KeywordDeleteDeniedException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
+++ b/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
@@ -5,20 +5,19 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.curation.dto.KeywordRequest;
 import team03.mopl.domain.curation.entity.Keyword;
 import team03.mopl.domain.curation.repository.KeywordRepository;
 import team03.mopl.domain.curation.service.CurationService;
+import team03.mopl.jwt.CustomUserDetails;
 
 @RestController
 @RequestMapping("/api/keywords")
@@ -26,7 +25,6 @@ import team03.mopl.domain.curation.service.CurationService;
 public class CurationController {
 
   private final CurationService curationService;
-  private final KeywordRepository keywordRepository;
 
   @PostMapping()
   public ResponseEntity<Keyword> registerKeyword(@RequestBody KeywordRequest request) {
@@ -37,17 +35,22 @@ public class CurationController {
   @GetMapping("/{keywordId}/contents")
   public ResponseEntity<List<Content>> getRecommendations(
       @PathVariable UUID keywordId,
-      @AuthenticationPrincipal UserDetails userDetails) {
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-    UUID userId = UUID.fromString(userDetails.getUsername());
+    UUID userId = userDetails.getId();
 
     List<Content> recommendations = curationService.getRecommendationsByKeyword(keywordId, userId);
     return ResponseEntity.ok(recommendations);
   }
 
   @DeleteMapping("/{keywordId}")
-  public ResponseEntity<Void> delete(@PathVariable UUID keywordId) {
-    curationService.delete(keywordId);
+  public ResponseEntity<Void> delete(
+      @PathVariable UUID keywordId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    UUID userId = userDetails.getId();
+
+    curationService.delete(keywordId, userId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/team03/mopl/domain/curation/service/CurationService.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationService.java
@@ -19,5 +19,5 @@ public interface CurationService {
 
   void updateContentRating(UUID contentId);
 
-  void delete(UUID keywordId);
+  void delete(UUID keywordId, UUID userId);
 }

--- a/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.mopl.common.exception.content.ContentNotFoundException;
+import team03.mopl.common.exception.curation.KeywordDeleteDeniedException;
 import team03.mopl.common.exception.curation.KeywordNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.content.Content;
@@ -644,9 +645,13 @@ public class CurationServiceImpl implements CurationService {
 
   @Override
   @Transactional
-  public void delete(UUID keywordId) {
+  public void delete(UUID keywordId, UUID userId) {
     Keyword keyword = keywordRepository.findById(keywordId)
             .orElseThrow(KeywordNotFoundException::new);
+
+    if (!keyword.getUser().getId().equals(userId)) {
+      throw new KeywordDeleteDeniedException();
+    }
 
     keywordRepository.delete(keyword);
   }


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->

## 🪐 작업 내용
### 1. keyword delete 메서드에 user 검증 로직 추가
 - keyword를 등록한 사용자가 아니면 삭제할 수 없도록

### 2. keyword 삭제 불가를 나타내는 custom exception 추가 

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?