### PR TITLE
fix: Keyword 별 콘텐츠 조회시 ContentDto 반환하도록 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
+++ b/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.curation.dto.KeywordRequest;
 import team03.mopl.domain.curation.entity.Keyword;
 import team03.mopl.domain.curation.repository.KeywordRepository;
@@ -34,13 +35,13 @@ public class CurationController {
   }
 
   @GetMapping("/{keywordId}/contents")
-  public ResponseEntity<List<Content>> getRecommendations(
+  public ResponseEntity<List<ContentDto>> getRecommendations(
       @PathVariable UUID keywordId,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     UUID userId = userDetails.getId();
 
-    List<Content> recommendations = curationService.getRecommendationsByKeyword(keywordId, userId);
+    List<ContentDto> recommendations = curationService.getRecommendationsByKeyword(keywordId, userId);
     return ResponseEntity.ok(recommendations);
   }
 

--- a/src/main/java/team03/mopl/domain/curation/service/CurationService.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationService.java
@@ -3,6 +3,7 @@ package team03.mopl.domain.curation.service;
 import java.util.List;
 import java.util.UUID;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.curation.entity.Keyword;
 
 public interface CurationService {
@@ -13,7 +14,7 @@ public interface CurationService {
 
   List<Content> curateContentForKeyword(Keyword keyword);
 
-  List<Content> getRecommendationsByKeyword(UUID keywordId, UUID userId);
+  List<ContentDto> getRecommendationsByKeyword(UUID keywordId, UUID userId);
 
   void batchCurationForNewContents(List<Content> newContents);
 

--- a/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
@@ -24,6 +24,7 @@ import team03.mopl.common.exception.curation.KeywordNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.repository.ContentRepository;
 import team03.mopl.domain.curation.entity.Keyword;
 import team03.mopl.domain.curation.entity.KeywordContent;
@@ -552,7 +553,7 @@ public class CurationServiceImpl implements CurationService {
 
   // TODO: 커서 페이지네이션
   @Override
-  public List<Content> getRecommendationsByKeyword(UUID keywordId, UUID userId) {
+  public List<ContentDto> getRecommendationsByKeyword(UUID keywordId, UUID userId) {
     Keyword keyword = keywordRepository.findByIdAndUserId(keywordId, userId)
         .orElseThrow(KeywordNotFoundException::new);
 
@@ -565,7 +566,9 @@ public class CurationServiceImpl implements CurationService {
           double score2 = calculateAIMatchingScore(keyword.getKeyword(), c2);
           return Double.compare(score2, score1); // 높은 점수부터
         })
-        .collect(Collectors.toList());
+        .toList()
+        .stream()
+    .map(ContentDto::from).toList();
   }
 
   // TODO: 배치작업

--- a/src/test/java/team03/mopl/domain/curation/CurationControllerTest.java
+++ b/src/test/java/team03/mopl/domain/curation/CurationControllerTest.java
@@ -21,6 +21,7 @@ import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.common.exception.curation.KeywordNotFoundException;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.curation.controller.CurationController;
 import team03.mopl.domain.curation.dto.KeywordRequest;
 import team03.mopl.domain.curation.entity.Keyword;
@@ -130,19 +131,19 @@ class CurationControllerTest {
           .avgRating(BigDecimal.valueOf(4.0))
           .build();
 
-      List<Content> mockRecommendations = List.of(mockContent1, mockContent2);
+      List<ContentDto> mockRecommendations = List.of(ContentDto.from(mockContent1), ContentDto.from(mockContent2));
 
       when(userDetails.getUsername()).thenReturn(userId.toString());
       when(curationService.getRecommendationsByKeyword(keywordId, userId)).thenReturn(mockRecommendations);
 
       // when
-      ResponseEntity<List<Content>> response = curationController.getRecommendations(keywordId, userDetails);
+      ResponseEntity<List<ContentDto>> response = curationController.getRecommendations(keywordId, userDetails);
 
       // then
       assertNotNull(response.getBody());
       assertEquals(2, response.getBody().size());
-      assertEquals(mockContent1.getTitle(), response.getBody().get(0).getTitle());
-      assertEquals(mockContent2.getTitle(), response.getBody().get(1).getTitle());
+      assertEquals(mockContent1.getTitle(), response.getBody().get(0).title());
+      assertEquals(mockContent2.getTitle(), response.getBody().get(1).title());
 
       verify(curationService).getRecommendationsByKeyword(keywordId, userId);
     }
@@ -154,13 +155,13 @@ class CurationControllerTest {
       UUID userId = UUID.randomUUID();
       UUID keywordId = UUID.randomUUID();
 
-      List<Content> emptyRecommendations = List.of();
+      List<ContentDto> emptyRecommendations = List.of();
 
       when(userDetails.getUsername()).thenReturn(userId.toString());
       when(curationService.getRecommendationsByKeyword(keywordId, userId)).thenReturn(emptyRecommendations);
 
       // when
-      ResponseEntity<List<Content>> response = curationController.getRecommendations(keywordId, userDetails);
+      ResponseEntity<List<ContentDto>> response = curationController.getRecommendations(keywordId, userDetails);
 
       // then
       assertNotNull(response.getBody());
@@ -176,13 +177,13 @@ class CurationControllerTest {
       UUID userId = UUID.randomUUID();
       UUID keywordId = UUID.randomUUID();
 
-      List<Content> mockRecommendations = List.of();
+      List<ContentDto> mockRecommendations = List.of();
 
       when(userDetails.getUsername()).thenReturn(userId.toString());
       when(curationService.getRecommendationsByKeyword(keywordId, userId)).thenReturn(mockRecommendations);
 
       // when
-      ResponseEntity<List<Content>> response = curationController.getRecommendations(keywordId, userDetails);
+      ResponseEntity<List<ContentDto>> response = curationController.getRecommendations(keywordId, userDetails);
 
       // then
       verify(userDetails).getUsername();

--- a/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.repository.ContentRepository;
 import team03.mopl.domain.curation.entity.Keyword;
 import team03.mopl.domain.curation.entity.KeywordContent;
@@ -238,11 +239,11 @@ class CurationServiceImplTest {
       when(keywordContentRepository.findByKeywordId(keywordId)).thenReturn(List.of(keywordContent));
 
       // when
-      List<Content> result = curationService.getRecommendationsByKeyword(keywordId, userId);
+      List<ContentDto> result = curationService.getRecommendationsByKeyword(keywordId, userId);
 
       // then
       assertNotNull(result);
-      assertEquals(content, result.get(0));
+      assertEquals(content.getTitle(), result.get(0).title());
 
       verify(keywordRepository, times(1)).findAllByUserId(userId);
     }
@@ -256,7 +257,7 @@ class CurationServiceImplTest {
       when(keywordRepository.findAllByUserId(userId)).thenReturn(List.of());
 
       // when
-      List<Content> result = curationService.getRecommendationsByKeyword(keywordId, userId);
+      List<ContentDto> result = curationService.getRecommendationsByKeyword(keywordId, userId);
 
       // then
       assertNotNull(result);


### PR DESCRIPTION
## 🛰️ Issue Number
- Keyword 별 콘텐츠 조회시 Cotent 엔티티 반환하던 것을 ContentDto 반환하도록 수정

## 🪐 작업 내용
- 테스트 코드 수정
- 컨트롤러 및 서비스 반환값 수정

## 기타
테스트 통과가 안되네요 ㅠㅠ 

- CurationControllerTest

<img width="306" alt="image" src="https://github.com/user-attachments/assets/0f9b3a71-02ad-4ef0-8c76-5b04c1457378" />

- CurationServiceImplTest 

<img width="307" alt="image" src="https://github.com/user-attachments/assets/ee6e15d7-0ec4-496c-98df-1159c5a75dc7" />


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?