### PR TITLE
fix: s3 읽기 설정

### DIFF
--- a/src/main/java/team03/mopl/storage/S3ProfileStorage.java
+++ b/src/main/java/team03/mopl/storage/S3ProfileStorage.java
@@ -9,6 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Component
@@ -30,6 +31,7 @@ public class S3ProfileStorage implements ProfileImageStorage{
               .bucket(bucket)
               .key(fileName)
               .contentType(file.getContentType())
+              .acl(ObjectCannedACL.PUBLIC_READ)
               .build(),
           software.amazon.awssdk.core.sync.RequestBody.fromInputStream(file.getInputStream(),
               file.getSize())


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->
- 읽기 열기
- 버킷 정책 이미지만 읽을 수 있게 정책 설정했습니다.
## 🪐 작업 내용
<!-- 예시
- Interest 생성(Create) 기능
  - 유사도 계산하여 유사도가 80%미만인 경우에만 등록 가능하도록 구현
  - 테스트 코드 추가
- 관심사 삭제 기능 추가
  - 기본적인 삭제 구현
  - 테스트 코드 추가
 -->

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?