### PR TITLE
feature: 알림 삭제 로직 구현 및 테스트 코드 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
@@ -50,9 +50,6 @@ public class DmServiceImpl implements DmService {
     dm.setDmRoom(dmRoom); // 연관관계 설정
 
     // 알림 전송 추가
-    System.out.println("sendDmDto = " + sendDmDto.getSenderId());
-    System.out.println("dmRoomgetSenderId = " + dmRoom.getSenderId());
-    System.out.println("dmRoomgetReceiverId = " + dmRoom.getReceiverId());
     if (dmRoom.getSenderId().equals(sendDmDto.getSenderId())) {
       UUID receiverId = dmRoom.getReceiverId(); // dmRoom의 senderId 로 등록된 사람 == dm 받는 사람
       notificationService.sendNotification(new NotificationDto(receiverId, NotificationType.DM_RECEIVED, sendDmDto.getContent()));
@@ -100,8 +97,6 @@ public class DmServiceImpl implements DmService {
 
     return CursorPageResponseDto.<DmDto>builder().data(dmDtoList).nextCursor(nextCursor).size(dmDtoList.size()).totalElements(totalElements)
         .hasNext(hasNext).build();
-
-    //return dmRepository.findByDmRoomIdOrderByCreatedAtAsc(roomId).stream().map(DmDto::from).collect(Collectors.toList());
   }
 
   private Cursor decodeCursor(String base64) {

--- a/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -69,6 +70,16 @@ public class NotificationController {
     log.info("알림 읽음 처리 완료: userId={}, 알림 수={}", userId, list.size());
     return ResponseEntity.ok(list);
   }
-
+  @DeleteMapping("/{notificationId}")
+  public ResponseEntity<Void> deleteNotification(@PathVariable("notificationId") UUID notificationId, @AuthenticationPrincipal CustomUserDetails user) {
+    notificationService.deleteNotification(notificationId);
+    return ResponseEntity.noContent().build();
+  }
+  @DeleteMapping("/user/{userId}")
+  public ResponseEntity<Void> deleteNotificationByUserId(@PathVariable("userId") UUID userId, @AuthenticationPrincipal CustomUserDetails user) {
+    UUID authenticatedUserId = user.getId();
+    notificationService.deleteNotificationByUserId(userId, authenticatedUserId);
+    return ResponseEntity.noContent().build();
+  }
 
 }

--- a/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
@@ -75,10 +75,10 @@ public class NotificationController {
     notificationService.deleteNotification(notificationId);
     return ResponseEntity.noContent().build();
   }
-  @DeleteMapping("/user/{userId}")
-  public ResponseEntity<Void> deleteNotificationByUserId(@PathVariable("userId") UUID userId, @AuthenticationPrincipal CustomUserDetails user) {
+  @DeleteMapping("/userId")
+  public ResponseEntity<Void> deleteNotificationByUserId(@AuthenticationPrincipal CustomUserDetails user) {
     UUID authenticatedUserId = user.getId();
-    notificationService.deleteNotificationByUserId(userId, authenticatedUserId);
+    notificationService.deleteNotificationByUserId(authenticatedUserId);
     return ResponseEntity.noContent().build();
   }
 

--- a/src/main/java/team03/mopl/domain/notification/dto/NotificationDto.java
+++ b/src/main/java/team03/mopl/domain/notification/dto/NotificationDto.java
@@ -10,29 +10,21 @@ import team03.mopl.domain.notification.entity.NotificationType;
 @Data
 @RequiredArgsConstructor
 public class NotificationDto {
-
+  private final UUID id;
   private final UUID receiverId;
   private final String content;
   private final NotificationType notificationType;
   private final LocalDateTime createdAt;
 
-  public NotificationDto(String content, NotificationType notificationType, LocalDateTime createdAt) {
-    this.receiverId = null;
-    this.content = content;
-    this.notificationType = notificationType;
-    this.createdAt = createdAt;
-  }
   public NotificationDto(UUID receiverId, NotificationType notificationType,String content) {
+    this.id = null;
     this.receiverId = receiverId;
     this.content = content;
     this.notificationType = notificationType;
     this.createdAt = null;
   }
 
-  public static NotificationDto from(String content, NotificationType notificationType, LocalDateTime createdAt) {
-    return new NotificationDto(content, notificationType, createdAt);
-  }
   public static NotificationDto from(Notification notification) {
-    return new NotificationDto(notification.getReceiverId(), notification.getContent(), notification.getType(), notification.getCreatedAt());
+    return new NotificationDto(notification.getId(), notification.getReceiverId(), notification.getContent(), notification.getType(), notification.getCreatedAt());
   }
 }

--- a/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
@@ -10,4 +10,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   List<Notification> findByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
 
   List<Notification> findByReceiverIdAndIsRead(UUID receiverId, boolean read);
+
+  void deleteByReceiverIdAndIsRead(UUID receiverId, boolean read);
 }

--- a/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
@@ -7,8 +7,6 @@ import team03.mopl.domain.notification.entity.Notification;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
 
-  List<Notification> findByReceiverIdOrderByCreatedAtDesc(UUID receiverId);
-
   List<Notification> findByReceiverIdAndIsRead(UUID receiverId, boolean read);
 
   void deleteByReceiverIdAndIsRead(UUID receiverId, boolean read);

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
@@ -12,5 +12,7 @@ public interface NotificationService {
   UUID sendNotification(NotificationDto notificationDto);
   CursorPageResponseDto<NotificationDto> getNotifications(NotificationPagingDto notificationPagingDto, UUID receiverId);
   void markAllAsRead(UUID notificationId);
+  void deleteNotification(UUID notificationId);
+  void deleteNotificationByUserId(UUID userId, UUID authenticatedUserId);
 }
 

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationService.java
@@ -13,6 +13,5 @@ public interface NotificationService {
   CursorPageResponseDto<NotificationDto> getNotifications(NotificationPagingDto notificationPagingDto, UUID receiverId);
   void markAllAsRead(UUID notificationId);
   void deleteNotification(UUID notificationId);
-  void deleteNotificationByUserId(UUID userId, UUID authenticatedUserId);
+  void deleteNotificationByUserId(UUID authenticatedUserId);
 }
-

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
@@ -112,14 +112,10 @@ public class NotificationServiceImpl implements NotificationService{
   }
   @Override
   @Transactional
-  public void deleteNotificationByUserId(UUID userId, UUID authenticatedUserId) {
-    log.info("deleteNotification - 알림 삭제 시도: userId={}", userId);
-    if( !authenticatedUserId.equals(userId) ) {
-      // 알림 소지한 ID와 인증된 객체가 같아야 한다.
-      throw new UserNotFoundException();
-    }
+  public void deleteNotificationByUserId(UUID authenticatedUserId) {
+    log.info("deleteNotification - 알림 삭제 시도: userId={}", authenticatedUserId);
     //읽지 않은 알림 빼고 삭제
-    notificationRepository.deleteByReceiverIdAndIsRead(userId, true);
-    log.info("deleteNotification - 알림 삭제 완료: userId={}", userId);
+    notificationRepository.deleteByReceiverIdAndIsRead(authenticatedUserId, true);
+    log.info("deleteNotification - 알림 삭제 완료: userId={}", authenticatedUserId);
   }
 }

--- a/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/notification/service/NotificationServiceImpl.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
+import team03.mopl.common.exception.notification.NotificationNotFoundException;
+import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.dm.dto.DmDto;
 import team03.mopl.domain.notification.dto.NotificationDto;
 import team03.mopl.domain.notification.dto.NotificationPagingDto;
@@ -100,4 +102,24 @@ public class NotificationServiceImpl implements NotificationService{
     log.info("markAllAsRead - 알림 읽음 처리 완료: receiverId={}, 읽은 알림 수={}", receiverId, unread.size());
   }
 
+  @Override
+  @Transactional
+  public void deleteNotification(UUID notificationId) {
+    log.info("deleteNotification - 알림 삭제 시도: notificationId={}", notificationId);
+    notificationRepository.findById(notificationId).orElseThrow(NotificationNotFoundException::new);
+    notificationRepository.deleteById(notificationId);
+    log.info("deleteNotification - 알림 삭제 완료: notificationId={}", notificationId);
+  }
+  @Override
+  @Transactional
+  public void deleteNotificationByUserId(UUID userId, UUID authenticatedUserId) {
+    log.info("deleteNotification - 알림 삭제 시도: userId={}", userId);
+    if( !authenticatedUserId.equals(userId) ) {
+      // 알림 소지한 ID와 인증된 객체가 같아야 한다.
+      throw new UserNotFoundException();
+    }
+    //읽지 않은 알림 빼고 삭제
+    notificationRepository.deleteByReceiverIdAndIsRead(userId, true);
+    log.info("deleteNotification - 알림 삭제 완료: userId={}", userId);
+  }
 }

--- a/src/test/java/team03/mopl/domain/follow/controller/FollowControllerTest.java
+++ b/src/test/java/team03/mopl/domain/follow/controller/FollowControllerTest.java
@@ -91,8 +91,7 @@ class FollowControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].email").value("user1@example.com"))
         .andExpect(jsonPath("$[0].name").value("user1"))
-        .andExpect(jsonPath("$[0].role").value("USER"))
-        .andExpect(jsonPath("$[0].isLocked").value(false));
+        .andExpect(jsonPath("$[0].role").value("USER"));
   }
 
   @Test
@@ -106,8 +105,7 @@ class FollowControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].email").value("follower@example.com"))
         .andExpect(jsonPath("$[0].name").value("follower"))
-        .andExpect(jsonPath("$[0].role").value("USER"))
-        .andExpect(jsonPath("$[0].isLocked").value(false));
+        .andExpect(jsonPath("$[0].role").value("USER"));
   }
 
   @Test

--- a/src/test/java/team03/mopl/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/team03/mopl/domain/notification/controller/NotificationControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -182,5 +183,36 @@ class NotificationControllerTest {
     ObjectMapper objectMapper = new ObjectMapper();
     String json = objectMapper.writeValueAsString(cursor);
     return Base64.getUrlEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  @DisplayName("유저의 읽은 알림 전체 삭제 API - 정상 동작")
+  void deleteNotificationByUserId() throws Exception {
+    // given
+    User user = User.builder()
+        .id(UUID.randomUUID())
+        .email("testuser@example.com")
+        .password("password")
+        .role(Role.USER)
+        .build();
+
+    CustomUserDetails customUserDetails = new CustomUserDetails(user);
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+        customUserDetails,
+        null,
+        customUserDetails.getAuthorities()
+    );
+    SecurityContextHolder.getContext().setAuthentication(authToken);
+
+    // when & then
+    mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                .delete("/api/notifications/user/" + user.getId())
+                .with(authentication(authToken))
+                .with(csrf())
+        )
+        .andExpect(status().isNoContent());
+
+    verify(notificationService).deleteNotificationByUserId(user.getId(), user.getId());
   }
 }

--- a/src/test/java/team03/mopl/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/notification/service/NotificationServiceImplTest.java
@@ -4,12 +4,23 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -94,6 +105,7 @@ class NotificationServiceImplTest {
     assertThat(result.data().get(1).getContent()).isEqualTo("DM 알림");
   }
 
+
   @Test
   @DisplayName("markAllAsRead - 모든 알림 읽음 처리")
   void markAllAsRead() {
@@ -120,7 +132,7 @@ class NotificationServiceImplTest {
     UUID authenticatedUserId = receiverId;
 
     // when
-    notificationService.deleteNotificationByUserId(receiverId, authenticatedUserId);
+    notificationService.deleteNotificationByUserId(authenticatedUserId);
 
     // then
     then(notificationRepository).should().deleteByReceiverIdAndIsRead(receiverId, true);
@@ -155,4 +167,6 @@ class NotificationServiceImplTest {
     then(notificationRepository).should().findById(notificationId);
     then(notificationRepository).shouldHaveNoMoreInteractions(); // deleteById가 호출되지 않았는지 확인
   }
+
+
 }


### PR DESCRIPTION
## 🛰️ Issue Number

- #128 

## 🪐 작업 내용
알림 삭제 로직 구현했습니다.
- 알림 ID를 통해 단일 삭제
- 유저 ID를 통해 읽은 알림 단체 삭제

-  followingControllerTest, NotificationServiceImplTest 테스트 코드 수정

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?