### PR TITLE
chore: 다국어 정렬 문제로 문자열 정렬 규칙 집합(Collation) 변경

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE "contents"
 (
     "id"               UUID PRIMARY KEY        NOT NULL,
     "title"            VARCHAR(255)            NOT NULL,
-    "title_normalized"            VARCHAR(255)            NOT NULL,
+    "title_normalized" VARCHAR(255) COLLATE "ko_KR.utf8" NOT NULL,
     "data_id"          varchar(255)            NULL,
     "description"      TEXT                    NULL,
     "content_type"     VARCHAR(50)             NOT NULL,


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
- 다국어 정렬 문제로 문자열 정렬 규칙 집합(Collation) 변경 en_US.utf8 -> ko_KR.utf8
```
CREATE TABLE "contents"
(
    "id"               UUID PRIMARY KEY                  NOT NULL,
    "title"            VARCHAR(255)                      NOT NULL,
    "title_normalized" VARCHAR(255) COLLATE "ko_KR.utf8" NOT NULL, # 여기 이렇게
   --  "title_normalized" VARCHAR(255) NOT NULL,
    "data_id"          varchar(255)                      NULL,
    "description"      TEXT                              NULL,
    "content_type"     VARCHAR(50)                       NOT NULL,
    "release_date"     TIMESTAMP                         NOT NULL,
    "avg_rating"       DECIMAL(3, 2)                     NULL CHECK (avg_rating >= 0.0 AND avg_rating <= 5.0),
    "created_at"       TIMESTAMP DEFAULT now()           NOT NULL,
    "url"              TEXT                              NULL
);
COMMENT ON COLUMN "contents"."content_type" IS 'ENUM';
CREATE INDEX idx_content_title ON contents (title);
CREATE INDEX idx_content_description ON contents (description);
```

어디 서비스에서 띄우느냐에 따라 허용할 수도 있고 아니할 수도 있는데, 그런 경우 주석 처리로 COLLATE "ko_KR.utf8" 적용을 지우고 DB생성해주시면 되겠습니다!(지원하지 않으면 저 컬럼 옵션으로 인해 테이블 생성 자체가 막힙니다!)

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?