### PR TITLE
fix: playlistDto 변경

### DIFF
--- a/src/main/java/team03/mopl/domain/playlist/dto/PlaylistDto.java
+++ b/src/main/java/team03/mopl/domain/playlist/dto/PlaylistDto.java
@@ -2,27 +2,37 @@ package team03.mopl.domain.playlist.dto;
 
 import java.util.List;
 import java.util.UUID;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.playlist.entity.Playlist;
 import team03.mopl.domain.playlist.entity.PlaylistContent;
-import team03.mopl.domain.subscription.Subscription;
+import team03.mopl.domain.subscription.dto.SubscriptionDto;
 import team03.mopl.domain.user.User;
 
 public record PlaylistDto(
-    UUID playlistId,
+    UUID id,
     String name,
     User user,
     Boolean isPublic,
-    List<PlaylistContent> playlistContents,
-    List<Subscription> subscriptions
+    List<ContentDto> playlistContents,
+    List<SubscriptionDto> subscriptions
 ) {
 
   public static PlaylistDto from(Playlist playlist) {
+    List<ContentDto> contentDtos = playlist.getPlaylistContents().stream()
+        .map(PlaylistContent::getContent)
+        .map(ContentDto::from)
+        .toList();
+
+    List<SubscriptionDto> subscriptionDtos = playlist.getSubscriptions().stream()
+        .map(SubscriptionDto::from)
+        .toList();
+
     return new PlaylistDto(
         playlist.getId(),
         playlist.getName(),
         playlist.getUser(),
         playlist.isPublic(),
-        playlist.getPlaylistContents(),
-        playlist.getSubscriptions());
+        contentDtos,
+        subscriptionDtos);
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #129 
<!-- 예시
- #11 
-->
Close #129 

## 🪐 작업 내용
- playlistDto 필드 변경 (entity -> dto)


변경 전
```
List<Content> contents,
List<Subscription> subscribers
```
변경 후
```
List<ContentDto> contents,
List<SubscriptionDto> subscribers
``` 

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?