### PR TITLE
fix: keywordContent @EntityListeners 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/curation/entity/KeywordContent.java
+++ b/src/main/java/team03/mopl/domain/curation/entity/KeywordContent.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.curation.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,6 +17,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import team03.mopl.domain.content.Content;
 
 @Getter
@@ -23,6 +25,7 @@ import team03.mopl.domain.content.Content;
 @Table(name = "keyword_contents", uniqueConstraints = {
     @UniqueConstraint(columnNames = {"keyword_id", "content_id"})
 })
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class KeywordContent {
 


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->

## 🪐 작업 내용
- keywordContent 엔티티에 @EntityListeners 어노테이션 추가

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?