### PR TITLE
fix: Subscription 엔티티 @EntityListeners 추가 및 생성 메서드 트랜젝션 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/subscription/Subscription.java
+++ b/src/main/java/team03/mopl/domain/subscription/Subscription.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.subscription;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +19,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import team03.mopl.domain.playlist.entity.Playlist;
 import team03.mopl.domain.user.User;
 
@@ -29,6 +31,7 @@ import team03.mopl.domain.user.User;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 public class Subscription {
 
   @Id

--- a/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
@@ -30,7 +30,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final PlaylistRepository playlistRepository;
 
   @Override
-  @Transactional(readOnly = true)
+  @Transactional
   public SubscriptionDto subscribe(UUID userId, UUID playlistId) {
     User user = userRepository.findById(userId)
         .orElseThrow(UserNotFoundException::new);


### PR DESCRIPTION
## 🛰️ Issue Number
- subscribe()를 사용하여도 Subscription 엔티티가 생성되지 않는 이슈 


## 🪐 작업 내용
- Subscription 엔티티 @EntityListeners 추가
- subscribe() 메서드의 @ Transactional(readOnly = true) -> @ Transactional로 수정

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?