### PR TITLE
chore: docker-compose.yml에 Redis, Kafka 컨테이너 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     // Security
     implementation 'org.springframework.security:spring-security-messaging'
 
-// AI - Stanford CoreNLP with JAXB exclusions
+    // AI - Stanford CoreNLP with JAXB exclusions
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation('edu.stanford.nlp:stanford-corenlp:4.5.4') {
         exclude group: 'javax.xml.bind', module: 'jaxb-api'
@@ -89,6 +89,13 @@ dependencies {
     // Database
     runtimeOnly 'org.postgresql:postgresql'
     runtimeOnly 'com.h2database:h2' // 테스트용
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
 
     // Test Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,36 +68,27 @@ services:
       - kafka_data:/var/lib/kafka/data
     environment:
       # 1. KRaft 모드 설정
-      KAFKA_PROCESS_ROLES: 'broker,controller'
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_PROCESS_ROLES: broker,controller
       KAFKA_NODE_ID: 1
-      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
 
       # 2. 리스너 설정
-      # 내부 리스너(INTERNAL)는 컨테이너 간 통신용
-      # 외부 리스너(EXTERNAL)는 Local PC -> 컨테이너 접속용
-      KAFKA_LISTENERS: 'INTERNAL://0.0.0.0:9092,CONTROLLER://kafka:9093'
-      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://kafka:9092' # Spring Boot App(backend)이 접속할 주소
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT'
-      KAFKA_INTER_BROKER_LISTENER_NAME: 'INTERNAL'
-      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
 
       # 3. 그 외 설정
+      # 오프셋 복제 개수
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      # 리밸런싱 대기 시간
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-
-    # 로그 디렉토리가 비어있을 때만 클러스터 ID 생성 및 포맷 실행
-    command: >
-      bash -c "
-        if [ ! -f /var/lib/kafka/data/cluster_id ]; then
-          export CLUSTER_ID=$(kafka-storage random-uuid)
-          echo '새로운 클러스터 ID로 Kafka storage 포맷: $CLUSTER_ID'
-          kafka-storage format -t $CLUSTER_ID -c /etc/kafka/kafka.properties
-          echo $CLUSTER_ID > /var/lib/kafka/data/cluster_id
-        fi
-      
-        # 항상 Kafka 서버는 실행
-        kafka-server-start /etc/kafka/kafka.properties
-      "
+      # 트랜잭션 로그 복제 개수
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      # 쓰기 허용 최소 복제본 수
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
 volumes:
   postgres-data:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,18 @@
+version: '3.7'
 services:
+  # Spring Boot Backend
   backend:
     container_name: mopl-container
     build:
       context: .
       dockerfile: Dockerfile
     ports:
-      - 8080:8080
+      - "8080:8080"
     depends_on:
       db:
         condition: service_healthy
+      kafka: # kafka가 먼저 실행되도록 의존성 추가
+        condition: service_started
     env_file:
       - ./.env
     environment:
@@ -18,12 +22,18 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://db:${POSTGRES_PORT}/${POSTGRES_DB}
       - SPRING_DATASOURCE_USERNAME=${POSTGRES_USER}
       - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
-      # REDIS, KAFKA 추가 시 환경변수 추가
+      # redis
+      - SPRING_REDIS_HOST=redis
+      - SPRING_REDIS_PORT=6379
+      # kafka
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+
+  # Database: PostgreSQL
   db:
-    container_name: postgresDB
+    container_name: postgreSQL
     image: postgres:14-alpine
     ports:
-      - 5432:5432
+      - "5432:5432"
     env_file:
       - ./.env
     environment:
@@ -38,5 +48,57 @@ services:
       timeout: 5s
       retries: 5
 
+  # Memory DB: Redis
+  redis:
+    container_name: redis
+    image: redis:7-alpine3.21
+    ports:
+      - 6379:6379
+    volumes:
+      - redis_data:/data
+
+  # Message Broker: Kafka (KRaft Mode)
+  kafka:
+    container_name: kafka
+    image: confluentinc/cp-kafka:7.4.10
+    ports:
+      - "9092:9092"
+    restart: always
+    volumes:
+      - kafka_data:/var/lib/kafka/data
+    environment:
+      # 1. KRaft 모드 설정
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+
+      # 2. 리스너 설정
+      # 내부 리스너(INTERNAL)는 컨테이너 간 통신용
+      # 외부 리스너(EXTERNAL)는 Local PC -> 컨테이너 접속용
+      KAFKA_LISTENERS: 'INTERNAL://0.0.0.0:9092,CONTROLLER://kafka:9093'
+      KAFKA_ADVERTISED_LISTENERS: 'INTERNAL://kafka:9092' # Spring Boot App(backend)이 접속할 주소
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'INTERNAL'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+
+      # 3. 그 외 설정
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+
+    # 로그 디렉토리가 비어있을 때만 클러스터 ID 생성 및 포맷 실행
+    command: >
+      bash -c "
+        if [ ! -f /var/lib/kafka/data/cluster_id ]; then
+          export CLUSTER_ID=$(kafka-storage random-uuid)
+          echo '새로운 클러스터 ID로 Kafka storage 포맷: $CLUSTER_ID'
+          kafka-storage format -t $CLUSTER_ID -c /etc/kafka/kafka.properties
+          echo $CLUSTER_ID > /var/lib/kafka/data/cluster_id
+        fi
+      
+        # 항상 Kafka 서버는 실행
+        kafka-server-start /etc/kafka/kafka.properties
+      "
 volumes:
   postgres-data:
+  redis_data:
+  kafka_data:


### PR DESCRIPTION
## 🛰️ Issue Number

- #172 

## 🪐 작업 내용
<img width="1440" height="445" alt="image" src="https://github.com/user-attachments/assets/13b0f2fb-59c5-48ad-8d93-1844b0c22f85" />

Redis, Kafka 컨테이너를 docker compose에 추가 했습니다.

**<주의사항>**
1. Kafka를 현재 이용하고 있지 않을시
Kafka의 경우 zookeeper와 함께 사용할 때의 크기가 더 나가서(1gb에 가까움), kRaft 모드로 등록해놨습니다.
그럼에도 불구하고 Kafka의 이미지 자체의 크기가 771.11MB 정도 하기 때문에, 현재 사용하지 않으시면 검색:kafka해서 관련 부분 주석 처리한 후 사용하시길 권장드립니다.

2. application-dev.yaml 업데이트
<img width="553" height="62" alt="image" src="https://github.com/user-attachments/assets/314fcb56-d7b9-49d9-827a-6874a2be65a6" />

수정된 환경 설정이 없을시 애플리케이션과 연동이 어렵습니다. 참고하십쇼!

---

언제 했는지 기억도 안나지만 (수정일자를 보니 06.25네요) 옛날에 이 두 개에 대해서 짧게 공부한 기록이있어 남기고 갑니다

<레디스>
https://lightning-shell-5dc.notion.site/Redis-21bea008b61c80939211cfb3c167dd26?source=copy_link
<카프카>
https://lightning-shell-5dc.notion.site/Kafka-21bea008b61c80c5946dd0e12cb95bc1?source=copy_link


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?