### PR TITLE
feature: 컨텐츠 썸네일/YouTube URL 컬럼 추가 및 적재 로직 개선

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -18,16 +18,17 @@ COMMENT ON COLUMN "users"."role" IS 'ENUM';
 -- 콘텐츠 테이블
 CREATE TABLE "contents"
 (
-    "id"               UUID PRIMARY KEY        NOT NULL,
-    "title"            VARCHAR(255)            NOT NULL,
+    "id"               UUID PRIMARY KEY                  NOT NULL,
+    "title"            VARCHAR(255)                      NOT NULL,
     "title_normalized" VARCHAR(255) COLLATE "ko_KR.utf8" NOT NULL,
-    "data_id"          varchar(255)            NULL,
-    "description"      TEXT                    NULL,
-    "content_type"     VARCHAR(50)             NOT NULL,
-    "release_date"     TIMESTAMP               NOT NULL,
-    "avg_rating"       DECIMAL(3, 2)           NULL CHECK (avg_rating >= 0.0 AND avg_rating <= 5.0),
-    "created_at"       TIMESTAMP DEFAULT now() NOT NULL,
-    "url"              TEXT                    NULL
+    "data_id"          varchar(255)                      NULL,
+    "description"      TEXT                              NULL,
+    "content_type"     VARCHAR(50)                       NOT NULL,
+    "release_date"     TIMESTAMP                         NOT NULL,
+    "avg_rating"       DECIMAL(3, 2)                     NULL CHECK (avg_rating >= 0.0 AND avg_rating <= 5.0),
+    "created_at"       TIMESTAMP DEFAULT now()           NOT NULL,
+    "youtube_url"      TEXT                              NOT NULL,
+    "thumbnail_url"    TEXT                              NULL
 );
 COMMENT ON COLUMN "contents"."content_type" IS 'ENUM';
 CREATE INDEX idx_content_title ON contents (title);
@@ -67,7 +68,7 @@ CREATE TABLE "reviews"
     "created_at" TIMESTAMP DEFAULT now() NOT NULL,
     "updated_at" TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("user_id", "content_id"),
-    FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ,
+    FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE,
     FOREIGN KEY ("content_id") REFERENCES "contents" ("id") ON DELETE CASCADE
 );
 
@@ -91,7 +92,7 @@ CREATE TABLE "playlist_contents"
     "content_id"  UUID                    NOT NULL,
     "created_at"  TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("playlist_id", "content_id"),
-    FOREIGN KEY ("playlist_id") REFERENCES "playlists" ("id") ON DELETE CASCADE ,
+    FOREIGN KEY ("playlist_id") REFERENCES "playlists" ("id") ON DELETE CASCADE,
     FOREIGN KEY ("content_id") REFERENCES "contents" ("id") ON DELETE CASCADE
 );
 
@@ -103,7 +104,7 @@ CREATE TABLE "subscriptions"
     "subscriber_id" UUID                    NOT NULL,
     "created_at"    TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("playlist_id", "subscriber_id"),
-    FOREIGN KEY ("playlist_id") REFERENCES "playlists" ("id") ON DELETE CASCADE ,
+    FOREIGN KEY ("playlist_id") REFERENCES "playlists" ("id") ON DELETE CASCADE,
     FOREIGN KEY ("subscriber_id") REFERENCES "users" ("id")
 );
 
@@ -124,7 +125,7 @@ CREATE TABLE "watch_rooms"
     "content_id"             UUID                           NOT NULL,
     "owner_id"               UUID                           NOT NULL,
     "created_at"             TIMESTAMP        DEFAULT now() NOT NULL,
-    "play_time"           DOUBLE PRECISION DEFAULT 0.0   NOT NULL,
+    "play_time"              DOUBLE PRECISION DEFAULT 0.0   NOT NULL,
     "is_playing"             BOOLEAN          DEFAULT FALSE NOT NULL,
     "video_state_updated_at" TIMESTAMP        DEFAULT now() NOT NULL,
     FOREIGN KEY ("owner_id") REFERENCES "users" ("id"),

--- a/src/main/java/team03/mopl/domain/content/Content.java
+++ b/src/main/java/team03/mopl/domain/content/Content.java
@@ -66,8 +66,11 @@ public class Content {
   @Column(name = "avg_rating", precision = 3, scale = 2)
   private BigDecimal avgRating;
 
-  @Column(name = "url")
-  private String url;
+  @Column(name = "youtube_url", nullable = false)
+  private String youtubeUrl;
+
+  @Column(name = "thumbnail_url")
+  private String thumbnailUrl;
 
   @Builder.Default
   @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/team03/mopl/domain/content/batch/launcher/SportsJobScheduler.java
+++ b/src/main/java/team03/mopl/domain/content/batch/launcher/SportsJobScheduler.java
@@ -25,7 +25,7 @@ public class SportsJobScheduler {
     this.sportsJob = sportsJob;
   }
 
-  @Scheduled(cron = "0 0 12 * * *")
+  @Scheduled(cron = "0 0 4 * * *")
   public void runSportsJob() {
     JobParameters jobParameters = new JobParametersBuilder()
         .addLong("timestamp", System.currentTimeMillis())

--- a/src/main/java/team03/mopl/domain/content/batch/launcher/TmdbJobScheduler.java
+++ b/src/main/java/team03/mopl/domain/content/batch/launcher/TmdbJobScheduler.java
@@ -24,7 +24,7 @@ public class TmdbJobScheduler {
     this.tmdbJob = tmdbJob;
   }
 
-  @Scheduled(fixedRate = 1000 * 60 * 60 * 48) // 48시간 마다 실행
+    @Scheduled(cron = "0 0 5 ? * FRI")
   public void runTmdbJob() {
     JobParameters jobParameters = new JobParametersBuilder()
         .addLong("timestamp", System.currentTimeMillis())

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
@@ -47,14 +47,21 @@ public class SportsApiProcessor implements ItemProcessor<SportsItemDto, Content>
     // 3. title 문자열 정규화
     String titleNormalized = NormalizerUtil.normalize(item.getStrFilename());
 
-    // 2. content 객체 생성및 반환
+    // 4. item.getStrVideo() 여부 확인
+    String strVideo = "";
+    if(item.getStrVideo() != null){
+      strVideo = item.getStrVideo();
+    }
+
+    // 5. content 객체 생성및 반환
     Content content = Content.builder()
         .title(item.getStrFilename())
         .titleNormalized(titleNormalized)
         .description(description.toString())
         .contentType(ContentType.SPORTS)
         .releaseDate(dateTime)
-        .url(item.getStrVideo())
+        .youtubeUrl(strVideo)
+        .thumbnailUrl(item.getStrThumb())
         .build();
 
     return content;

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsItemDto.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsItemDto.java
@@ -39,4 +39,7 @@ public class SportsItemDto {
   @JsonProperty("strVideo")
   private String strVideo;
 
+  @JsonProperty("strThumb")
+  private String strThumb;
+
 }

--- a/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbApiProcessor.java
+++ b/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbApiProcessor.java
@@ -30,7 +30,7 @@ public class TmdbApiProcessor implements ItemProcessor<TmdbItemDto, Content> {
   public Content process(TmdbItemDto item) throws Exception {
 
     if (contentRepository.existsByDataId(item.getId())) {
-      log.info("이미 존재하는 Content 입니다. item.getId()={}", item.getId());
+      log.debug("이미 존재하는 Content: item.getId()={}", item.getId());
       return null;
     }
 
@@ -92,10 +92,21 @@ public class TmdbApiProcessor implements ItemProcessor<TmdbItemDto, Content> {
        // log.info("videoUrl={}", videoUrl);
     }
 
+    if (videoUrl.isEmpty()){
+      log.debug("YouTube URL 부재: item.getId()={}", item.getId());
+      return null;
+    }
+
     // 9. title 문자열 정규화
     String titleNormalized = NormalizerUtil.normalize(title);
 
-    // 10. Content 객체 생성및 반환
+    // 10. thumbnail URL 생성: 전체 경로, 원본 이미지
+    String thumbnailUrl = "";
+    if(item.getPosterPath() != null){
+      thumbnailUrl = "https://image.tmdb.org/t/p/original" + item.getPosterPath();
+    }
+
+    // 11. Content 객체 생성및 반환
     Content content = Content.builder()
         .title(title)
         .titleNormalized(titleNormalized)
@@ -103,7 +114,8 @@ public class TmdbApiProcessor implements ItemProcessor<TmdbItemDto, Content> {
         .description(item.getOverview())
         .contentType(contentType)
         .releaseDate(releaseDate)
-        .url(videoUrl)
+        .youtubeUrl(videoUrl)
+        .thumbnailUrl(thumbnailUrl)
         .build();
 
     return content;

--- a/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbApiReader.java
+++ b/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbApiReader.java
@@ -196,12 +196,12 @@ public class TmdbApiReader implements ItemStreamReader<TmdbItemDto> {
 
     } else if ("tv".equals(videoType)) {
       LocalDate today = LocalDate.now();
-      LocalDate yesterday = today.minusDays(1);
+      LocalDate weekAgo  = today.minusDays(7);
 
       return UriComponentsBuilder
           .fromUriString(baseurl)
           .path("/discover/tv")
-          .queryParam("air_date.gte", yesterday)
+          .queryParam("air_date.gte", weekAgo)
           .queryParam("air_date.lte", today)
           .queryParam("include_adult", "false")
           .queryParam("include_null_first_air_dates", "false")

--- a/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbItemDto.java
+++ b/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbItemDto.java
@@ -23,4 +23,7 @@ public class TmdbItemDto {
 
   @JsonProperty("first_air_date")
   private String firstAirDate;
+
+  @JsonProperty("poster_path")
+  private String posterPath;
 }

--- a/src/main/java/team03/mopl/domain/content/dto/ContentDto.java
+++ b/src/main/java/team03/mopl/domain/content/dto/ContentDto.java
@@ -13,7 +13,8 @@ public record ContentDto (
     String description,
     ContentType contentType,
     LocalDateTime releaseDate,
-    String url // nullable
+    String youtubeUrl,
+    String thumbnailUrl
 ){
   public static ContentDto from(Content content){
     return new ContentDto(
@@ -24,7 +25,8 @@ public record ContentDto (
         content.getDescription(),
         content.getContentType(),
         content.getReleaseDate(),
-        content.getUrl()
+        content.getYoutubeUrl(),
+        content.getThumbnailUrl()
     );
   }
 }

--- a/src/test/java/team03/mopl/domain/content/repository/ContentRepositoryImplTest.java
+++ b/src/test/java/team03/mopl/domain/content/repository/ContentRepositoryImplTest.java
@@ -65,13 +65,16 @@ class ContentRepositoryImplTest {
         List<Content> contents = List.of(
             Content.builder().title("제목필터링테스트1-검색됨").titleNormalized("제목필터링테스트1-검색됨")
                 .releaseDate(LocalDateTime.parse("2025-06-25T10:00"))
-                .contentType(ContentType.MOVIE).build(),
+                .contentType(ContentType.MOVIE)
+                .youtubeUrl("").build(),
             Content.builder().title("제목필터링테스트2-검색됨").titleNormalized("제목필터링테스트2-검색됨")
                 .releaseDate(LocalDateTime.parse("2019-07-09T10:00"))
-                .contentType(ContentType.MOVIE).build(),
+                .contentType(ContentType.MOVIE)
+                .youtubeUrl("").build(),
             Content.builder().title("제목필터링테스트3-안됨").titleNormalized("제목필터링테스트3-안됨")
                 .releaseDate(LocalDateTime.parse("2019-07-09T10:00"))
-                .contentType(ContentType.MOVIE).build()
+                .contentType(ContentType.MOVIE)
+                .youtubeUrl("").build()
         );
         contentRepository.saveAll(contents);
 
@@ -100,13 +103,15 @@ class ContentRepositoryImplTest {
         List<Content> contents = List.of(
             Content.builder().title("컨텐츠타입필터링1").titleNormalized("컨텐츠타입필터링1")
                 .releaseDate(LocalDateTime.parse("2025-06-25T10:00"))
-                .contentType(ContentType.MOVIE).build(),
+                .contentType(ContentType.MOVIE)
+                .youtubeUrl("").build(),
             Content.builder().title("컨텐츠타입필터링2").titleNormalized("컨텐츠타입필터링2")
                 .releaseDate(LocalDateTime.parse("2019-07-09T10:00"))
-                .contentType(ContentType.MOVIE).build(),
+                .contentType(ContentType.MOVIE)
+                .youtubeUrl("").build(),
             Content.builder().title("컨텐츠타입필터링3").titleNormalized("컨텐츠타입필터링3")
                 .releaseDate(LocalDateTime.parse("2019-07-09T10:00")).contentType(ContentType.TV)
-                .build()
+                .youtubeUrl("").build()
         );
         contentRepository.saveAll(contents);
 
@@ -135,7 +140,7 @@ class ContentRepositoryImplTest {
         List<Content> contents = List.of(
             Content.builder().title("존재하는데이터").titleNormalized("존재하는데이터")
                 .releaseDate(LocalDateTime.parse("2025-06-25T10:00"))
-                .contentType(ContentType.MOVIE).build()
+                .contentType(ContentType.MOVIE).youtubeUrl("").build()
         );
         contentRepository.saveAll(contents);
 
@@ -169,22 +174,22 @@ class ContentRepositoryImplTest {
       List<Content> contents = List.of(
           Content.builder().title("1").titleNormalized("1")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("2").titleNormalized("2")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("A").titleNormalized("A")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("B").titleNormalized("B")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("가").titleNormalized("가")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("나").titleNormalized("나")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build()
+              .youtubeUrl("").build()
       );
       contentRepository.saveAll(contents);
 
@@ -215,22 +220,22 @@ class ContentRepositoryImplTest {
       List<Content> contents = List.of(
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-06-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-05-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-04-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-03-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("더미").titleNormalized("더미")
               .releaseDate(LocalDateTime.parse("2025-02-07T10:00")).contentType(ContentType.MOVIE)
-              .build()
+              .youtubeUrl("").build()
       );
       contentRepository.saveAll(contents);
 
@@ -262,22 +267,22 @@ class ContentRepositoryImplTest {
       List<Content> contents = List.of(
           Content.builder().title("1").titleNormalized("1")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("2").titleNormalized("2")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("A").titleNormalized("A")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("B").titleNormalized("B")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("가").titleNormalized("가")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("나").titleNormalized("나")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build()
+              .youtubeUrl("").build()
       );
       contentRepository.saveAll(contents);
 
@@ -331,14 +336,14 @@ class ContentRepositoryImplTest {
       List<Content> contents = List.of(
           Content.builder().title("Ç").titleNormalized("C")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           Content.builder().title("B-").titleNormalized("B")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build(),
+              .youtubeUrl("").build(),
           //
           Content.builder().title("A").titleNormalized("A")
               .releaseDate(LocalDateTime.parse("2025-07-07T10:00")).contentType(ContentType.MOVIE)
-              .build()
+              .youtubeUrl("").build()
       );
       contentRepository.saveAll(contents);
 
@@ -352,7 +357,8 @@ class ContentRepositoryImplTest {
       int size = 2;
 
       // when
-      List<Content> firstPageresults = contentRepository.findContentsWithCursor(title, contentType, sortBy,
+      List<Content> firstPageresults = contentRepository.findContentsWithCursor(title, contentType,
+          sortBy,
           direction, cursor, cursorId, size);
 
       // then
@@ -364,12 +370,13 @@ class ContentRepositoryImplTest {
 
       // 두번째 페이지
       // given
-      Content lastContentFirstPage = firstPageresults.get(size-1);
+      Content lastContentFirstPage = firstPageresults.get(size - 1);
       String nextCursor = lastContentFirstPage.getTitleNormalized();
       UUID nextCursorId = lastContentFirstPage.getId();
 
       // when
-      List<Content> secondPageResults = contentRepository.findContentsWithCursor(title, contentType, sortBy,
+      List<Content> secondPageResults = contentRepository.findContentsWithCursor(title, contentType,
+          sortBy,
           direction, nextCursor, nextCursorId, size);
 
       // then


### PR DESCRIPTION
## 🛰️ Issue Number

- #178 

## 🪐 작업 내용

- [x]  컨텐츠 테이블에 썸네일 URL 추가 + 로직 변경
    - [x]  TMDB
    - [x]  Sports
- [x]  schema.sql 변경
    - [x]  url : 컬럼명 변경 youtube_url, Nullable 여부 변경 NULL → NOT NULL
    - [x]  thumnail_url 추가
- [x]  유튜브 url 가진 것만 적재하도록 변경
    - [x]  TMDB
    - [x]  Sports
  
**초기 적재를 통해 youtube_url, thumnail_url 적재 확인**

1. ContentType: MOVIE의 youtube_url, thumnail_url 적재
<img width="1666" height="522" alt="image" src="https://github.com/user-attachments/assets/e8014f8e-e841-4f4f-b7de-75cf4a177e3e" />

2. ContentType: SPORTS의 youtube_url, thumnail_url 적재
<img width="1654" height="429" alt="image" src="https://github.com/user-attachments/assets/e58ed977-7600-4105-a2d6-3a27e2910c38" />

3. ContentType: TV의 youtube_url, thumnail_url 적재
<img width="1666" height="247" alt="image" src="https://github.com/user-attachments/assets/b6a0a6fe-c723-4ace-9d65-f1f83d6ff370" />


-----

- [x] 컨텐츠 적재 - 배치 시작 시간 개선 및 API 개선


**1. TMDB**
<img width="1717" height="1048" alt="image" src="https://github.com/user-attachments/assets/7fac4c64-8829-4430-ad4d-98d4667dc81d" />
유튜브 URL 없으면 적재x → 주기적 적재할 때 Item이 총 0개 적재되는 문제 발생

(이전) movie나 tv의 주기적 적재를 만들면서 고민을 많이 했던 게 movie나 tv는 매일매일 컨텐츠가 뜨는 컨텐츠(특히 다들 알음알음 알 정도면)들이 아니기도 해서, 매일 적재로도 들고올 수 있는 데이터가 적겠다~ 생각은 했으나, 5~10개 정도는 적재되어 유지했습니다.
(변경된 부분) 그러나 유튜브 URL 없으면 적재하지 않는 로직을 추가하니 Item이 하나도 적재 되지 않아  →→→→

(현재) TMDB의 경우 “매일”이 아닌 “금요일” 새벽 5시에 적재되는 것으로 변경했습니다.

- TV의 경우 일주일 전부터 지금까지 당일 방영한 것을 적재
- MOVIE는 “현재 상영 중” 이므로 유지시켰습니다.
2025년 7월 15일 기준으로 일주일 전까지 적재해봤는데 20개 적재되는 것 확인했습니다!

그외 좋은 생각이 있다면 공유해주세요!


**2. Sports**
한국시각 새벽 12시 → 4시로 변경


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?