### PR TITLE
feature: AVG_RATING기준 페이지네이션 기능 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/content/Content.java
+++ b/src/main/java/team03/mopl/domain/content/Content.java
@@ -63,8 +63,9 @@ public class Content {
   @Column(name = "release_date", nullable = false)
   private LocalDateTime releaseDate;
 
+  @Builder.Default
   @Column(name = "avg_rating", precision = 3, scale = 2)
-  private BigDecimal avgRating;
+  private BigDecimal avgRating = BigDecimal.ZERO;
 
   @Column(name = "youtube_url", nullable = false)
   private String youtubeUrl;

--- a/src/main/java/team03/mopl/domain/content/SortBy.java
+++ b/src/main/java/team03/mopl/domain/content/SortBy.java
@@ -2,5 +2,6 @@ package team03.mopl.domain.content;
 
 public enum SortBy {
   TITLE,
-  RELEASE_AT
+  RELEASE_AT,
+  AVG_RATING
 }

--- a/src/main/java/team03/mopl/domain/content/dto/ContentDto.java
+++ b/src/main/java/team03/mopl/domain/content/dto/ContentDto.java
@@ -1,5 +1,6 @@
 package team03.mopl.domain.content.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import team03.mopl.domain.content.Content;
@@ -14,7 +15,8 @@ public record ContentDto (
     ContentType contentType,
     LocalDateTime releaseDate,
     String youtubeUrl,
-    String thumbnailUrl
+    String thumbnailUrl,
+    BigDecimal avgRating
 ){
   public static ContentDto from(Content content){
     return new ContentDto(
@@ -26,7 +28,8 @@ public record ContentDto (
         content.getContentType(),
         content.getReleaseDate(),
         content.getYoutubeUrl(),
-        content.getThumbnailUrl()
+        content.getThumbnailUrl(),
+        content.getAvgRating()
     );
   }
 }

--- a/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
+++ b/src/main/java/team03/mopl/domain/content/dto/ContentSearchRequest.java
@@ -32,7 +32,7 @@ public class ContentSearchRequest {
   private String contentType = "MOVIE";
 
   @Parameter
-  @AllowedValues(enumClass = SortBy.class, message = "sortBy는 TITLE, RELEASE_AT 중 하나여야 합니다.")
+  @AllowedValues(enumClass = SortBy.class, message = "sortBy는 TITLE, RELEASE_AT, AVG_RATING 중 하나여야 합니다.")
   private String sortBy = "TITLE";
 
   @Parameter

--- a/src/main/java/team03/mopl/domain/content/repository/ContentRepositoryImpl.java
+++ b/src/main/java/team03/mopl/domain/content/repository/ContentRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -39,11 +40,11 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
     boolean isDesc = "DESC".equalsIgnoreCase(direction);
     Order orderDirection = isDesc ? Order.DESC : Order.ASC;
     // 2. 정렬 기준에 따른 OrderSpecifier 설정 : 기준값 기본은 title
-    OrderSpecifier<?> mainSort;
+    OrderSpecifier<?> mainSort = new OrderSpecifier<>(orderDirection, content.titleNormalized);
     if ("RELEASE_AT".equalsIgnoreCase(sortBy)) {
       mainSort = new OrderSpecifier<>(orderDirection, content.releaseDate);
-    } else {
-      mainSort = new OrderSpecifier<>(orderDirection, content.titleNormalized);
+    } else if ("AVG_RATING".equalsIgnoreCase(sortBy)) {
+      mainSort = new OrderSpecifier<>(orderDirection, content.avgRating);
     }
     OrderSpecifier<?> idSort = new OrderSpecifier<>(orderDirection, content.id);
 
@@ -100,8 +101,8 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
         return content.releaseDate.gt(localDateTimeCursor)
             .or(content.releaseDate.eq(localDateTimeCursor).and(content.id.gt(cursorId)));
       }
-    } else {
-      if(isDesc){
+    } else if (sortBy.equalsIgnoreCase("TITLE")) {
+      if (isDesc) {
         // 내림차순: 커서 제목보다 사전적으로 이전 제목이되 동일한 제목일시 id가 더 큰 값들 
         return content.titleNormalized.lt(cursor)
             .or(content.titleNormalized.eq(cursor).and(content.id.lt(cursorId)));
@@ -109,6 +110,15 @@ public class ContentRepositoryImpl implements ContentRepositoryCustom {
         // 오름차순: 커서 제목보다 사전적으로 이후 제목이되 동일한 제목일시 id가 더 큰 값들
         return content.titleNormalized.gt(cursor)
             .or(content.titleNormalized.eq(cursor).and(content.id.gt(cursorId)));
+      }
+    } else { //AVG_RATING
+      BigDecimal bigDecimalCursor = new BigDecimal(cursor);
+      if (isDesc) {
+        return content.avgRating.lt(bigDecimalCursor)
+            .or(content.avgRating.eq(bigDecimalCursor).and(content.id.lt(cursorId)));
+      } else {
+        return content.avgRating.gt(bigDecimalCursor)
+            .or(content.avgRating.eq(bigDecimalCursor).and(content.id.gt(cursorId)));
       }
     }
   }

--- a/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
@@ -182,8 +182,10 @@ public class ContentServiceImpl implements ContentService {
     String lastValue;
     if (sortBy.equalsIgnoreCase("RELEASE_AT")) {
       lastValue = contentDto.releaseDate().toString();
-    } else {
+    } else if(sortBy.equalsIgnoreCase("TITLE")) {
       lastValue = contentDto.titleNormalized();
+    } else { // AVG_RATING
+      lastValue = contentDto.avgRating().toString();
     }
 
     Cursor cursor = new Cursor(lastValue, lastId);


### PR DESCRIPTION
## 🛰️ Issue Number

- #178 

## 🪐 작업 내용

**ContentRepositoryImplTest**
재밌는?! 사실을 하나 알게된 건

```
    assertThat(secondPageResults.get(0).getId().toString())
        .isLessThan(lastContentFirstPage.getId().toString())
```
됨

```
    assertThat(secondPageResults.get(0).getId())
        .isLessThan(lastContentFirstPage.getId())
```
안됨 입니다.

DB에서 비교하는 것과 자바에서 비교하는 것과 결과가 다르다고 합니다.
DB에서는 UUID를 보통 바이트나 String으로 비교하기 때문에 저희가 알고 있는 사전순의 정렬이 가능한거고, 자바에서는 부호가 있는 long으로 취급하여 양수, 음수 기준으로 대소 비교를 하게 돼 원하는 것과 다른 정렬 형태가 나오게 된다고 하네요.

----

사용자의 입력을 통해 정렬이 이뤄지는 건 실제 입력 데이터가 들어온 후 상황을 보고 에러를 잡아야 해서 재배포 완료 후 한번 더 봐야할 것 같습니다.

- 계정 여러개 생생하기
- 리뷰 작성하기
- 시청방 만들기

(QA 라고 해야할까요!?) 이런 것들 같이 진행해보면 좋을 것 같습니다.

[사담]
<img width="257" height="197" alt="image" src="https://github.com/user-attachments/assets/48eaedc8-59d1-49c6-8efd-471bfd186d3c" />
(저번 프로젝트 때도 사용자 입력에 따라 데이터 정렬되는 걸 했어서 계속 팀원 분들한테 데이터 달라고 졸랐던 기억이... )


## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?