### PR TITLE
chore: application-prod.yaml redis 관련 환경 설정 추가

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -26,6 +26,14 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+      password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
+
   batch:
     jdbc:
       initialize-schema: never


### PR DESCRIPTION
## 🛰️ Issue Number

- #191 

## 🪐 작업 내용

**1. application-prod.yaml에 redis 관련 설정을 추가했습니다.
2. mopl.env를 업데이트 했습니다.(→ 아직 S3 버킷에는 업데이트 되어있지 않은 상태)
3. AWS에서 ElastiCache 클라스터 생성 완료**
<img width="877" height="244" alt="image" src="https://github.com/user-attachments/assets/486b878d-5281-48b6-a872-dbdbf4e03ac2" />
Valkey는 AWS에서 앞으로 주력으로 지원 Redis 호환 오픈소스입니다.(Redis를 그대로 포크해옴)

**4. mopl03-team 계정에 ElastiCache 관련 권한을 부여해뒀습니다.**

---
## 팀원님들께...
https://lightning-shell-5dc.notion.site/Redis-232ea008b61c8090a821dca65aa67298?pvs=74
ElastiCache에 Redis 서버를 띄우면서 선택의 이유나 과정을 메모해둔 문서입니다.
캐시 노드 유형을 선택하기 위해 만들어둔 **장표**가 있으니, 궁금하실 때 확인해보시라고 노션 문서 링크 추가 업로드하고 갑니다! (물론 글이 많은 만큼 질문을 하셔도 언제나 OK)
<img width="609" height="299" alt="image" src="https://github.com/user-attachments/assets/2a478155-4c76-4124-8e10-9da15d908971" />


## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?