### PR TITLE
refactor: curation pagination, 비동기, event 처리

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -50,11 +50,15 @@ CREATE TABLE "keyword_contents"
     "id"         UUID PRIMARY KEY        NOT NULL,
     "keyword_id" UUID                    NOT NULL,
     "content_id" UUID                    NOT NULL,
+    "score"      DECIMAL                 NOT NULL,
     "created_at" TIMESTAMP DEFAULT now() NOT NULL,
+    "updated_at" TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("keyword_id", "content_id"),
     FOREIGN KEY ("keyword_id") REFERENCES "keywords" ("id") ON DELETE CASCADE,
     FOREIGN KEY ("content_id") REFERENCES "contents" ("id") ON DELETE CASCADE
 );
+CREATE INDEX idx_keyword_score ON keyword_contents(keyword_id, score DESC, content_id);
+CREATE INDEX idx_content_updated ON keyword_contents(content_id, updated_at);
 
 -- 리뷰 테이블
 CREATE TABLE "reviews"

--- a/src/main/java/team03/mopl/common/config/AsyncConfig.java
+++ b/src/main/java/team03/mopl/common/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package team03.mopl.common.config;
+
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+  @Bean("scoreCalculationExecutor")
+  public TaskExecutor scoreCalculationExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(4);
+    executor.setQueueCapacity(10);
+    executor.setThreadNamePrefix("ScoreCalc-");
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor.initialize();
+    return executor;
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/ErrorCode.java
+++ b/src/main/java/team03/mopl/common/exception/ErrorCode.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+  INVALID_CURSOR_FORMAT(HttpStatus.BAD_REQUEST, "PAGINATION_001", "올바르지 않은 커서 형식입니다."),
+  INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "PAGINATION_002", "페이지 사이즈가 올바르지 않습니다."),
 
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 사용자입니다."),
   DUPLICATED_EMAIL(HttpStatus.CONFLICT, "USER_002", "이미 사용중인 이메일입니다"),
@@ -15,28 +17,33 @@ public enum ErrorCode {
 
   //Content
   CONTENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CONTENT_001", "존재하지 않는 콘텐츠입니다."),
+  CONTENT_RATING_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CONTENT_002", "콘텐츠 평점 업데이트에 실패했습니다."),
 
   REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW_001", "존재하지 않는 리뷰입니다."),
   REVIEW_DELETE_DENIED(HttpStatus.FORBIDDEN, "REVIEW_002", "본인의 리뷰만 삭제할 수 있습니다."),
   REVIEW_UPDATE_DENIED(HttpStatus.FORBIDDEN, "REVIEW_003", "본인의 리뷰만 수정할 수 있습니다."),
   DUPLICATED_REVIEW(HttpStatus.CONFLICT, "REVIEW_004", "해당 콘텐츠에 이미 리뷰를 작성했습니다."),
 
-
   CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "CHATROOM_001", "존재하지 않는 채팅방입니다."),
   ALREADY_JOINED_CHATROOM(HttpStatus.CREATED, "CHATROOM_002", "이미 참여중인 채팅방입니다."),
+
   //DM
   DM_NOT_FOUND(HttpStatus.NOT_FOUND, "DM_001", "존재하지 않는 다이렉트 메시지입니다."),
   DM_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "DM_001", "존재하지 않는 채팅방입니다."),
   DM_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "DM_002", "메시지 길이가 255자를 초과할 수 없습니다."),
+
   //Follow
   FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW_001", "존재하지 않는 팔로우입니다."),
   ALREADY_FOLLOWING(HttpStatus.BAD_REQUEST, "FOLLOW_002", "이미 팔로우하고 있습니다."),
   CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST, "FOLLOW_003", "자기 자신을 팔로우하고 있습니다."),
-  //Notification
+
+  //Notification,
   NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "존재하지 않는 알림입니다."),
 
   KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "KEYWORD_001", "해당 사용자의 키워드를 찾을 수 없습니다."),
   KEYWORD_DELETE_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "KEYWORD_002", "본인의 키워드만 삭제할 수 있습니다."),
+
+  INVALID_SCORE_RANGE(HttpStatus.BAD_REQUEST, "CURATION_001", "점수 범위가 올바르지 않습니다."),
 
   SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBSCRIPTION_001", "구독 기록을 찾을 수 없습니다."),
   ALREADY_SUBSCRIBED(HttpStatus.CONFLICT, "SUBSCRIPTION_002", "이미 구독 중인 플레이리스트입니다."),

--- a/src/main/java/team03/mopl/common/exception/InvalidCursorFormatException.java
+++ b/src/main/java/team03/mopl/common/exception/InvalidCursorFormatException.java
@@ -1,0 +1,22 @@
+package team03.mopl.common.exception;
+
+import java.util.Map;
+
+public class InvalidCursorFormatException extends MoplException {
+
+  public InvalidCursorFormatException() {
+    super(ErrorCode.INVALID_CURSOR_FORMAT);
+  }
+
+  public InvalidCursorFormatException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public InvalidCursorFormatException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+
+  public InvalidCursorFormatException(Throwable cause) {
+    super(ErrorCode.INVALID_CURSOR_FORMAT, cause);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/InvalidPageSizeException.java
+++ b/src/main/java/team03/mopl/common/exception/InvalidPageSizeException.java
@@ -1,0 +1,19 @@
+package team03.mopl.common.exception;
+
+import java.util.Map;
+import team03.mopl.common.exception.curation.CurationException;
+
+public class InvalidPageSizeException extends CurationException {
+
+  public InvalidPageSizeException() {
+    super(ErrorCode.INVALID_PAGE_SIZE);
+  }
+
+  public InvalidPageSizeException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public InvalidPageSizeException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/curation/ContentRatingUpdateException.java
+++ b/src/main/java/team03/mopl/common/exception/curation/ContentRatingUpdateException.java
@@ -1,0 +1,23 @@
+package team03.mopl.common.exception.curation;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class ContentRatingUpdateException extends CurationException {
+
+  public ContentRatingUpdateException() {
+    super(ErrorCode.CONTENT_RATING_UPDATE_FAILED);
+  }
+
+  public ContentRatingUpdateException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public ContentRatingUpdateException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+
+  public ContentRatingUpdateException(Throwable cause) {
+    super(ErrorCode.CONTENT_RATING_UPDATE_FAILED, cause);
+  }
+}

--- a/src/main/java/team03/mopl/common/exception/curation/InvalidScoreRangeException.java
+++ b/src/main/java/team03/mopl/common/exception/curation/InvalidScoreRangeException.java
@@ -1,0 +1,19 @@
+package team03.mopl.common.exception.curation;
+
+import java.util.Map;
+import team03.mopl.common.exception.ErrorCode;
+
+public class InvalidScoreRangeException extends CurationException {
+
+  public InvalidScoreRangeException() {
+    super(ErrorCode.INVALID_SCORE_RANGE);
+  }
+
+  public InvalidScoreRangeException(ErrorCode errorCode, Throwable cause) {
+    super(errorCode, cause);
+  }
+
+  public InvalidScoreRangeException(ErrorCode errorCode, Map<String, Object> details) {
+    super(errorCode, details);
+  }
+}

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
@@ -32,7 +32,7 @@ public class SportsBatchConfig {
 
   @Bean
   public Job sportsJob() {
-    return new JobBuilder("sportsJob", jobRepository)
+    return new JobBuilder("sportCurationJob", jobRepository)
         .start(sportsStep())
         .listener(curationJobListener)
         .build();

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
@@ -1,7 +1,9 @@
 package team03.mopl.domain.content.batch.sports;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
@@ -13,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.curation.CurationJobListener;
 
 @Configuration
 @RequiredArgsConstructor
@@ -22,9 +25,18 @@ public class SportsBatchConfig {
   private final PlatformTransactionManager transactionManager;
   private final ItemWriter<Content> itemWriter;
   private final JobRepository jobRepository;
+  private final CurationJobListener curationJobListener;
 
   @Value("${sports.baseurl}")
   private String baseUrl;
+
+  @Bean
+  public Job sportsJob() {
+    return new JobBuilder("sportsJob", jobRepository)
+        .start(sportsStep())
+        .listener(curationJobListener)
+        .build();
+  }
 
   @Bean
   public Step initialSportsStep(){

--- a/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbBatchConfig.java
@@ -36,7 +36,7 @@ public class TmdbBatchConfig {
 
   @Bean
   public Job tmdbJob() {
-    return new JobBuilder("tmdbJob", jobRepository)
+    return new JobBuilder("tmdbCurationJob", jobRepository)
         .start(tmdbStep())
         .listener(curationJobListener)
         .build();

--- a/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/content/batch/tmdb/TmdbBatchConfig.java
@@ -1,7 +1,9 @@
 package team03.mopl.domain.content.batch.tmdb;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
@@ -14,6 +16,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.curation.CurationJobListener;
 
 @Configuration
 @RequiredArgsConstructor
@@ -24,11 +27,20 @@ public class TmdbBatchConfig {
   private final JobRepository jobRepository;
   private final PlatformTransactionManager transactionManager;
   private final ItemWriter<Content> itemWriter;
+  private final CurationJobListener curationJobListener;
 
   @Value("${tmdb.baseurl}")
   private String baseurl;
   @Value("${tmdb.api_token}")
   private String apiToken;
+
+  @Bean
+  public Job tmdbJob() {
+    return new JobBuilder("tmdbJob", jobRepository)
+        .start(tmdbStep())
+        .listener(curationJobListener)
+        .build();
+  }
 
   @Bean
   public Step initialTmdbStep(){

--- a/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
+++ b/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
@@ -1,5 +1,6 @@
 package team03.mopl.domain.content.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -27,4 +28,37 @@ public interface ContentRepository extends JpaRepository<Content, UUID>, Content
       "(:contentType IS NULL OR c.contentType = :contentType)")
   long countByTitleAndContentType(@Param("title") String title,
       @Param("contentType") String contentType);
+
+  // 최근 TMDB 콘텐츠 조회 (예: 최근 1시간 내)
+  @Query("SELECT c FROM Content c WHERE c.createdAt >= :since AND c.contentType IN ('MOVIE', 'TV')")
+  List<Content> findRecentTmdbContents(@Param("since") LocalDateTime since);
+
+  default List<Content> findRecentTmdbContents() {
+    return findRecentTmdbContents(LocalDateTime.now().minusHours(1));
+  }
+
+  // 최근 Sports 콘텐츠 조회
+  @Query("SELECT c FROM Content c WHERE c.createdAt >= :since AND c.contentType = 'SPORTS'")
+  List<Content> findRecentSportsContents(@Param("since") LocalDateTime since);
+
+  default List<Content> findRecentSportsContents() {
+    return findRecentSportsContents(LocalDateTime.now().minusHours(1));
+  }
+
+  // 큐레이션 상태 확인용 메서드들
+  @Query("SELECT COUNT(DISTINCT c.id) FROM Content c JOIN KeywordContent kc ON c.id = kc.content.id")
+  long countCuratedContents();
+
+  @Query("SELECT k.keyword, COUNT(kc), AVG(kc.score) FROM KeywordContent kc JOIN kc.keyword k GROUP BY k.keyword")
+  List<Object[]> getKeywordContentStats();
+
+  @Query("SELECT c FROM Content c WHERE c.createdAt >= :since")
+  List<Content> findRecentContents(@Param("since") LocalDateTime since);
+
+  default List<Content> findRecentContents(int daysBack) {
+    return findRecentContents(LocalDateTime.now().minusDays(daysBack));
+  }
+
+  @Query("SELECT c FROM Content c ORDER BY c.id LIMIT :limit OFFSET :offset")
+  List<Content> findAllWithOffset(@Param("offset") int offset, @Param("limit") int limit);
 }

--- a/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
+++ b/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
@@ -23,12 +23,6 @@ public interface ContentRepository extends JpaRepository<Content, UUID>, Content
         """, nativeQuery = true)
   List<Content> findAllWithPagination(@Param("offset") int offset, @Param("limit") int limit);
 
-  @Query("SELECT COUNT(c) FROM Content c WHERE " +
-      "(:title IS NULL OR c.titleNormalized LIKE %:title%) AND " +
-      "(:contentType IS NULL OR c.contentType = :contentType)")
-  long countByTitleAndContentType(@Param("title") String title,
-      @Param("contentType") String contentType);
-
   // 최근 TMDB 콘텐츠 조회 (예: 최근 1시간 내)
   @Query("SELECT c FROM Content c WHERE c.createdAt >= :since AND c.contentType IN ('MOVIE', 'TV')")
   List<Content> findRecentTmdbContents(@Param("since") LocalDateTime since);
@@ -44,13 +38,6 @@ public interface ContentRepository extends JpaRepository<Content, UUID>, Content
   default List<Content> findRecentSportsContents() {
     return findRecentSportsContents(LocalDateTime.now().minusHours(1));
   }
-
-  // 큐레이션 상태 확인용 메서드들
-  @Query("SELECT COUNT(DISTINCT c.id) FROM Content c JOIN KeywordContent kc ON c.id = kc.content.id")
-  long countCuratedContents();
-
-  @Query("SELECT k.keyword, COUNT(kc), AVG(kc.score) FROM KeywordContent kc JOIN kc.keyword k GROUP BY k.keyword")
-  List<Object[]> getKeywordContentStats();
 
   @Query("SELECT c FROM Content c WHERE c.createdAt >= :since")
   List<Content> findRecentContents(@Param("since") LocalDateTime since);

--- a/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
+++ b/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
@@ -1,7 +1,10 @@
 package team03.mopl.domain.content.repository;
 
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
 
@@ -10,4 +13,18 @@ public interface ContentRepository extends JpaRepository<Content, UUID>, Content
   boolean existsByContentType(ContentType contentType);
 
   boolean existsByDataId(String dataId);
+
+  // 배치 처리를 위한 페이징 조회
+  @Query(value = """
+        SELECT * FROM content c 
+        ORDER BY c.id 
+        LIMIT :limit OFFSET :offset
+        """, nativeQuery = true)
+  List<Content> findAllWithPagination(@Param("offset") int offset, @Param("limit") int limit);
+
+  @Query("SELECT COUNT(c) FROM Content c WHERE " +
+      "(:title IS NULL OR c.titleNormalized LIKE %:title%) AND " +
+      "(:contentType IS NULL OR c.contentType = :contentType)")
+  long countByTitleAndContentType(@Param("title") String title,
+      @Param("contentType") String contentType);
 }

--- a/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
@@ -15,7 +15,6 @@ import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.domain.content.Content;
-import team03.mopl.domain.content.ContentType;
 import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.dto.ContentSearchRequest;
 import team03.mopl.domain.content.repository.ContentRepository;

--- a/src/main/java/team03/mopl/domain/curation/CurationBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/curation/CurationBatchConfig.java
@@ -1,0 +1,76 @@
+package team03.mopl.domain.curation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.curation.service.CurationService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CurationBatchConfig {
+
+  private final CurationService curationService;
+  private final ContentRepository contentRepository;
+
+  /**
+   * 모든 콘텐츠에 대한 큐레이션 재계산 배치 작업
+   */
+  public void executeFullCurationBatch() {
+    log.info("executeFullCurationBatch - 전체 큐레이션 재계산 시작");
+
+    try {
+      final int BATCH_SIZE = 100;
+      int offset = 0;
+      int totalProcessed = 0;
+
+      while (true) {
+        List<Content> contentBatch = contentRepository.findAllWithOffset(offset, BATCH_SIZE);
+
+        if (contentBatch.isEmpty()) {
+          break;
+        }
+
+        // 배치 단위로 큐레이션 수행
+        curationService.batchCurationForNewContents(contentBatch);
+
+        totalProcessed += contentBatch.size();
+        offset += BATCH_SIZE;
+
+        log.info("executeFullCurationBatch - 진행 상황: {}개 처리", totalProcessed);
+
+        // 시스템 부하 방지를 위한 대기
+        Thread.sleep(1000);
+      }
+
+      log.info("executeFullCurationBatch - 전체 큐레이션 재계산 완료: {}개 처리", totalProcessed);
+
+    } catch (Exception e) {
+      log.warn("executeFullCurationBatch - 전체 큐레이션 재계산 실패", e);
+    }
+  }
+
+  /**
+   * 특정 기간 내 생성된 콘텐츠에 대한 큐레이션 배치 작업
+   */
+  public void executeRecentContentsCuration(int daysBack) {
+    log.info("executeRecentContentsCuration - 최근 {}일 콘텐츠 큐레이션 시작", daysBack);
+
+    try {
+      List<Content> recentContents = contentRepository.findRecentContents(daysBack);
+
+      if (!recentContents.isEmpty()) {
+        curationService.batchCurationForNewContents(recentContents);
+        log.info("executeRecentContentsCuration - 최근 콘텐츠 큐레이션 완료: {}개", recentContents.size());
+      } else {
+        log.info("executeRecentContentsCuration - 최근 {}일 내 콘텐츠가 없습니다", daysBack);
+      }
+
+    } catch (Exception e) {
+      log.warn("executeRecentContentsCuration - 최근 콘텐츠 큐레이션 실패", e);
+    }
+  }
+}

--- a/src/main/java/team03/mopl/domain/curation/CurationJobListener.java
+++ b/src/main/java/team03/mopl/domain/curation/CurationJobListener.java
@@ -1,0 +1,104 @@
+package team03.mopl.domain.curation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.annotation.AfterJob;
+import org.springframework.batch.core.annotation.BeforeJob;
+import org.springframework.stereotype.Component;
+import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.curation.service.CurationService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CurationJobListener implements JobExecutionListener {
+
+  private final CurationService curationService;
+  private final ContentRepository contentRepository;
+
+  @BeforeJob
+  public void beforeJob(JobExecution jobExecution) {
+    String jobName = jobExecution.getJobInstance().getJobName();
+    log.info("CurationJobListener - 배치 작업 시작: {}", jobName);
+  }
+
+  @AfterJob
+  public void afterJob(JobExecution jobExecution) {
+    String jobName = jobExecution.getJobInstance().getJobName();
+
+    if (jobExecution.getStatus().isUnsuccessful()) {
+      log.warn("CurationJobListener - 배치 작업 실패로 큐레이션 작업 건너뜀: {}", jobName);
+      return;
+    }
+
+    log.info("CurationJobListener - 배치 작업 완료 후 큐레이션 작업 시작: {}", jobName);
+
+    try {
+      // 각 배치 작업에 따라 다른 큐레이션 전략 적용
+      switch (jobName) {
+        case "tmdbJob":
+          handleTmdbJobCompletion(jobExecution);
+          break;
+        case "sportsJob":
+          handleSportsJobCompletion(jobExecution);
+          break;
+        default:
+          log.info("CurationJobListener - 알 수 없는 배치 작업: {}", jobName);
+      }
+    } catch (Exception e) {
+      log.error("CurationJobListener - 큐레이션 작업 실패: {}", jobName, e);
+    }
+  }
+
+  /**
+   * TMDB 배치 작업 완료 후 큐레이션 처리
+   */
+  private void handleTmdbJobCompletion(JobExecution jobExecution) {
+    log.info("handleTmdbJobCompletion - TMDB 큐레이션 작업 시작");
+
+    // Step 실행 정보에서 처리된 아이템 수 확인
+    long processedItems = jobExecution.getStepExecutions().stream()
+        .mapToLong(StepExecution::getWriteCount)
+        .sum();
+
+    log.info("handleTmdbJobCompletion - 처리된 TMDB 콘텐츠: {}개", processedItems);
+
+    if (processedItems > 0) {
+      // 최근에 추가된 TMDB 콘텐츠들을 조회하여 큐레이션 수행
+      List<Content> recentTmdbContents = contentRepository.findRecentTmdbContents();
+
+      if (!recentTmdbContents.isEmpty()) {
+        curationService.batchCurationForNewContents(recentTmdbContents);
+        log.info("handleTmdbJobCompletion - TMDB 큐레이션 완료: {}개 콘텐츠", recentTmdbContents.size());
+      }
+    }
+  }
+
+  /**
+   * Sports 배치 작업 완료 후 큐레이션 처리
+   */
+  private void handleSportsJobCompletion(JobExecution jobExecution) {
+    log.info("handleSportsJobCompletion - Sports 큐레이션 작업 시작");
+
+    long processedItems = jobExecution.getStepExecutions().stream()
+        .mapToLong(StepExecution::getWriteCount)
+        .sum();
+
+    log.info("handleSportsJobCompletion - 처리된 Sports 콘텐츠: {}개", processedItems);
+
+    if (processedItems > 0) {
+      // 최근에 추가된 Sports 콘텐츠들을 조회하여 큐레이션 수행
+      List<Content> recentSportsContents = contentRepository.findRecentSportsContents();
+
+      if (!recentSportsContents.isEmpty()) {
+        curationService.batchCurationForNewContents(recentSportsContents);
+        log.info("handleSportsJobCompletion - Sports 큐레이션 완료: {}개 콘텐츠", recentSportsContents.size());
+      }
+    }
+  }
+}

--- a/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
+++ b/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
@@ -3,6 +3,7 @@ package team03.mopl.domain.curation.controller;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,7 +38,7 @@ public class CurationController {
   @GetMapping("/{keywordId}/contents")
   public ResponseEntity<CursorPageResponseDto<ContentDto>> getRecommendations(
       @PathVariable UUID keywordId,
-      @ModelAttribute CursorPageRequest request,
+      @ParameterObject @ModelAttribute CursorPageRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     UUID userId = userDetails.getId();

--- a/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
+++ b/src/main/java/team03/mopl/domain/curation/controller/CurationController.java
@@ -1,19 +1,21 @@
 package team03.mopl.domain.curation.controller;
 
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.curation.dto.CursorPageRequest;
 import team03.mopl.domain.curation.dto.KeywordDto;
 import team03.mopl.domain.curation.dto.KeywordRequest;
 import team03.mopl.domain.curation.service.CurationService;
@@ -33,13 +35,14 @@ public class CurationController {
   }
 
   @GetMapping("/{keywordId}/contents")
-  public ResponseEntity<List<ContentDto>> getRecommendations(
+  public ResponseEntity<CursorPageResponseDto<ContentDto>> getRecommendations(
       @PathVariable UUID keywordId,
+      @ModelAttribute CursorPageRequest request,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
 
     UUID userId = userDetails.getId();
 
-    List<ContentDto> recommendations = curationService.getRecommendationsByKeyword(keywordId, userId);
+    CursorPageResponseDto<ContentDto> recommendations = curationService.getRecommendationsByKeyword(keywordId, userId, request);
     return ResponseEntity.ok(recommendations);
   }
 

--- a/src/main/java/team03/mopl/domain/curation/dto/ContentWithScoreDto.java
+++ b/src/main/java/team03/mopl/domain/curation/dto/ContentWithScoreDto.java
@@ -1,0 +1,21 @@
+package team03.mopl.domain.curation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import team03.mopl.domain.content.dto.ContentDto;
+
+@Builder
+public record ContentWithScoreDto(
+    @JsonProperty("content") ContentDto content,
+    @JsonProperty("score") double score,
+    @JsonProperty("contentId") String contentId
+) {
+
+  public static ContentWithScoreDto from(ContentDto content, double score) {
+    return ContentWithScoreDto.builder()
+        .content(content)
+        .score(score)
+        .contentId(content.id().toString())
+        .build();
+  }
+}

--- a/src/main/java/team03/mopl/domain/curation/dto/CursorPageRequest.java
+++ b/src/main/java/team03/mopl/domain/curation/dto/CursorPageRequest.java
@@ -1,0 +1,17 @@
+package team03.mopl.domain.curation.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CursorPageRequest(
+    String cursor,
+    int size
+) {
+  public static CursorPageRequest of(String cursor, int size) {
+    return CursorPageRequest.builder()
+        .cursor(cursor)
+        .size(Math.min(size, 50))
+        .build();
+  }
+
+}

--- a/src/main/java/team03/mopl/domain/curation/entity/KeywordContent.java
+++ b/src/main/java/team03/mopl/domain/curation/entity/KeywordContent.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -14,19 +15,29 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import team03.mopl.domain.content.Content;
 
 @Getter
 @Entity
-@Table(name = "keyword_contents", uniqueConstraints = {
-    @UniqueConstraint(columnNames = {"keyword_id", "content_id"})
-})
+@Builder
+@Table(name = "keyword_contents",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"keyword_id", "content_id"})
+    },
+    indexes = {
+        @Index(name = "idx_keyword_score", columnList = "keyword_id, score DESC, content_id"),
+        @Index(name = "idx_content_updated", columnList = "content_id, updated_at")
+    })
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class KeywordContent {
 
   @Id
@@ -41,12 +52,24 @@ public class KeywordContent {
   @JoinColumn(name = "content_id", nullable = false)
   private Content content;
 
+  @Column(nullable = false)
+  private Double score;
+
   @CreatedDate
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
-  public KeywordContent(Keyword keyword, Content content) {
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  public KeywordContent(Keyword keyword, Content content, Double score) {
     this.keyword = keyword;
     this.content = content;
+    this.score = score;
+  }
+
+  public void updateScore(Double newScore) {
+    this.score = newScore;
   }
 }

--- a/src/main/java/team03/mopl/domain/curation/repository/KeywordContentRepository.java
+++ b/src/main/java/team03/mopl/domain/curation/repository/KeywordContentRepository.java
@@ -31,7 +31,6 @@ public interface KeywordContentRepository extends JpaRepository<KeywordContent, 
   );
 
   // 키워드별 점수 존재 여부 확인
-  @Query("SELECT COUNT(kc) > 0 FROM KeywordContent kc WHERE kc.keyword.id = :keywordId")
   boolean existsByKeywordId(@Param("keywordId") UUID keywordId);
 
   // 키워드별 총 추천 콘텐츠 수

--- a/src/main/java/team03/mopl/domain/curation/repository/KeywordContentRepository.java
+++ b/src/main/java/team03/mopl/domain/curation/repository/KeywordContentRepository.java
@@ -3,6 +3,9 @@ package team03.mopl.domain.curation.repository;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team03.mopl.domain.curation.entity.KeywordContent;
 
 public interface KeywordContentRepository extends JpaRepository<KeywordContent, UUID> {
@@ -11,5 +14,37 @@ public interface KeywordContentRepository extends JpaRepository<KeywordContent, 
 
   boolean existsByKeywordIdAndContentId(UUID keywordId, UUID contentId);
 
-  void deleteByKeywordId(UUID keywordId);
+  @Query(value = """
+      SELECT * FROM keyword_contents kc 
+      WHERE kc.keyword_id = :keywordId 
+      AND (:cursorScore IS NULL OR 
+           (kc.score < :cursorScore OR 
+            (kc.score = :cursorScore AND kc.content_id > CAST(:cursorContentId AS uuid))))
+      ORDER BY kc.score DESC, kc.content_id ASC
+      LIMIT :limit
+      """, nativeQuery = true)
+  List<KeywordContent> findByKeywordIdWithPagination(
+      @Param("keywordId") UUID keywordId,
+      @Param("cursorScore") Double cursorScore,
+      @Param("cursorContentId") String cursorContentId,
+      @Param("limit") int limit
+  );
+
+  // 키워드별 점수 존재 여부 확인
+  @Query("SELECT COUNT(kc) > 0 FROM KeywordContent kc WHERE kc.keyword.id = :keywordId")
+  boolean existsByKeywordId(@Param("keywordId") UUID keywordId);
+
+  // 키워드별 총 추천 콘텐츠 수
+  @Query("SELECT COUNT(kc) FROM KeywordContent kc WHERE kc.keyword.id = :keywordId")
+  long countByKeywordId(@Param("keywordId") UUID keywordId);
+
+  // 특정 키워드의 모든 점수 삭제 (재계산 시 사용)
+  @Modifying
+  @Query("DELETE FROM KeywordContent kc WHERE kc.keyword.id = :keywordId")
+  void deleteByKeywordId(@Param("keywordId") UUID keywordId);
+
+  // 임계값 이상 점수만 조회
+  @Query("SELECT kc FROM KeywordContent kc WHERE kc.keyword.id = :keywordId AND kc.score >= :threshold ORDER BY kc.score DESC")
+  List<KeywordContent> findByKeywordIdAndScoreGreaterThanEqual(@Param("keywordId") UUID keywordId, @Param("threshold") Double threshold);
+
 }

--- a/src/main/java/team03/mopl/domain/curation/service/CurationService.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationService.java
@@ -2,8 +2,11 @@ package team03.mopl.domain.curation.service;
 
 import java.util.List;
 import java.util.UUID;
+import org.springframework.transaction.annotation.Transactional;
+import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.curation.dto.CursorPageRequest;
 import team03.mopl.domain.curation.dto.KeywordDto;
 import team03.mopl.domain.curation.entity.Keyword;
 
@@ -13,9 +16,13 @@ public interface CurationService {
 
   KeywordDto registerKeyword(UUID userId, String keywordText);
 
-  List<ContentDto> curateContentForKeyword(Keyword keyword);
-
-  List<ContentDto> getRecommendationsByKeyword(UUID keywordId, UUID userId);
+  // 메인 추천 조회 메서드
+  @Transactional(readOnly = true)
+  CursorPageResponseDto<ContentDto> getRecommendationsByKeyword(
+      UUID keywordId,
+      UUID userId,
+      CursorPageRequest request
+  );
 
   List<KeywordDto> getKeywordsByUser(UUID userId);
 

--- a/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/curation/service/CurationServiceImpl.java
@@ -253,7 +253,7 @@ public class CurationServiceImpl implements CurationService {
 
     // 점수가 계산되어 있는지 확인
     if (!keywordContentRepository.existsByKeywordId(keywordId)) {
-      return handleMissingScores(keyword, request);
+      return handleMissingScores(keyword);
     }
 
     // 커서 파싱 (예외 처리 개선)
@@ -392,8 +392,7 @@ public class CurationServiceImpl implements CurationService {
 
   // 점수가 없을 때 처리
   private CursorPageResponseDto<ContentDto> handleMissingScores(
-      Keyword keyword,
-      CursorPageRequest request
+      Keyword keyword
   ) {
     log.warn("점수 계산이 완료되지 않음 - 키워드 ID: {}", keyword.getId());
 

--- a/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/curation/CurationServiceImplTest.java
@@ -1,7 +1,7 @@
 package team03.mopl.domain.curation;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.math.BigDecimal;
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,12 +18,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import team03.mopl.common.dto.CursorPageResponseDto;
+import team03.mopl.common.exception.InvalidCursorFormatException;
+import team03.mopl.common.exception.InvalidPageSizeException;
+import team03.mopl.common.exception.content.ContentNotFoundException;
+import team03.mopl.common.exception.curation.ContentRatingUpdateException;
+import team03.mopl.common.exception.curation.KeywordDeleteDeniedException;
 import team03.mopl.common.exception.curation.KeywordNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
 import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.curation.dto.CursorPageRequest;
 import team03.mopl.domain.curation.dto.KeywordDto;
 import team03.mopl.domain.curation.entity.Keyword;
 import team03.mopl.domain.curation.entity.KeywordContent;
@@ -37,7 +46,7 @@ import team03.mopl.domain.user.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("큐레이션 서비스 테스트")
-class CurationServiceImplTest {
+class CurationServiceTest {
 
   @Mock
   private ReviewService reviewService;
@@ -57,61 +66,96 @@ class CurationServiceImplTest {
   @InjectMocks
   private CurationServiceImpl curationService;
 
-  // 테스트용 유저
+  private User testUser;
+  private Keyword testKeyword;
+  private Content testContent;
   private UUID userId;
-  private User user;
-
-  // 테스트용 콘텐츠
-  private UUID contentId;
-  private Content content;
-
-  // 테스트용 키워드
   private UUID keywordId;
-  private Keyword keyword;
+  private UUID contentId;
 
   @BeforeEach
   void setUp() {
+    // 매 테스트마다 독립적인 UUID 생성
     userId = UUID.randomUUID();
-    user = User.builder()
+    keywordId = UUID.randomUUID();
+    contentId = UUID.randomUUID();
+
+    // 테스트 데이터 초기화
+    testUser = User.builder()
         .id(userId)
         .name("테스트유저")
         .email("test@test.com")
-        .password("test")
+        .password("password")
         .role(Role.USER)
         .build();
 
-    contentId = UUID.randomUUID();
-    content = Content.builder()
+    testKeyword = Keyword.builder()
+        .id(keywordId)
+        .user(testUser)
+        .keyword("액션")
+        .build();
+
+    testContent = Content.builder()
         .id(contentId)
-        .title("테스트 액션 영화")
-        .description("액션과 모험이 가득한 영화입니다.")
+        .title("액션 영화")
+        .description("액션과 모험이 가득한 영화")
         .contentType(ContentType.MOVIE)
         .releaseDate(LocalDateTime.now())
         .avgRating(BigDecimal.valueOf(4.5))
         .build();
 
-    keywordId = UUID.randomUUID();
-    keyword = Keyword.builder()
-        .id(keywordId)
-        .user(user)
-        .keyword("액션")
-        .build();
+    // Mock 초기화
+    reset(reviewService, contentRepository, keywordRepository, keywordContentRepository,
+        userRepository);
   }
 
   @Nested
-  @DisplayName("키워드 등록")
-  class RegisterKeyword {
+  @DisplayName("키워드 등록 테스트")
+  class RegisterKeywordTest {
 
     @Test
-    @DisplayName("성공")
-    void success() {
+    @DisplayName("성공적인 키워드 등록")
+    void registerKeyword_Success() {
       // given
       String keywordText = "액션";
+      when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+      when(keywordRepository.save(any(Keyword.class))).thenReturn(testKeyword);
 
-      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-      when(keywordRepository.save(any(Keyword.class))).thenReturn(keyword);
-      when(contentRepository.findAll()).thenReturn(List.of(content));
-      when(keywordContentRepository.save(any(KeywordContent.class))).thenReturn(new KeywordContent(keyword, content));
+      // when
+      KeywordDto result = curationService.registerKeyword(userId, keywordText);
+
+      // then
+      assertNotNull(result);
+      assertEquals(userId, result.userId());
+      assertEquals("액션", result.keyword());
+
+      verify(userRepository).findById(userId);
+      verify(keywordRepository).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자로 키워드 등록 시 예외 발생")
+    void registerKeyword_UserNotFound() {
+      // given
+      String keywordText = "액션";
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThrows(UserNotFoundException.class, () -> {
+        curationService.registerKeyword(userId, keywordText);
+      });
+
+      verify(userRepository).findById(userId);
+      verify(keywordRepository, never()).save(any(Keyword.class));
+    }
+
+    @Test
+    @DisplayName("공백 키워드 정규화")
+    void registerKeyword_WithWhitespace() {
+      // given
+      String keywordText = "  액션  ";
+      when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+      when(keywordRepository.save(any(Keyword.class))).thenReturn(testKeyword);
 
       // when
       KeywordDto result = curationService.registerKeyword(userId, keywordText);
@@ -119,401 +163,266 @@ class CurationServiceImplTest {
       // then
       assertNotNull(result);
       assertEquals("액션", result.keyword());
-      assertEquals(userId, result.userId());
 
-      verify(keywordRepository, times(1)).save(any(Keyword.class));
-      verify(contentRepository, times(1)).findAll();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 유저")
-    void failsWhenUserNotFound() {
-      // given
-      UUID randomUserId = UUID.randomUUID();
-      String keywordText = "액션";
-
-      when(userRepository.findById(randomUserId)).thenReturn(Optional.empty());
-
-      // when & then
-      assertThrows(UserNotFoundException.class,
-          () -> curationService.registerKeyword(randomUserId, keywordText));
-
-      verify(keywordRepository, never()).save(any(Keyword.class));
-    }
-
-    @Test
-    @DisplayName("다국어 키워드 정규화")
-    void normalizeMultilingualKeyword() {
-      // given
-      String keywordText = "Action Movie!!!";
-
-      when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-      when(keywordRepository.save(any(Keyword.class))).thenReturn(keyword);
-      when(contentRepository.findAll()).thenReturn(List.of());
-
-      // when
-      KeywordDto result = curationService.registerKeyword(userId, keywordText);
-
-      // then
-      assertNotNull(result);
-      verify(keywordRepository, times(1)).save(any(Keyword.class));
+      verify(userRepository).findById(userId);
+      verify(keywordRepository).save(any(Keyword.class));
     }
   }
 
   @Nested
-  @DisplayName("키워드별 콘텐츠 큐레이션")
-  class CurateContentForKeyword {
+  @DisplayName("키워드별 추천 조회 테스트")
+  class GetRecommendationsByKeywordTest {
 
     @Test
-    @DisplayName("성공")
-    void success() {
+    @DisplayName("성공적인 추천 조회")
+    void getRecommendations_Success() {
       // given
-      Content actionMovie = Content.builder()
-          .id(UUID.randomUUID())
-          .title("액션 블록버스터")
-          .description("최고의 액션 영화")
-          .contentType(ContentType.MOVIE)
-          .avgRating(BigDecimal.valueOf(4.8))
+      CursorPageRequest request = new CursorPageRequest(null, 10);
+
+      when(keywordRepository.findByIdAndUserId(keywordId, userId))
+          .thenReturn(Optional.of(testKeyword));
+      when(keywordContentRepository.existsByKeywordId(keywordId))
+          .thenReturn(true);
+
+      KeywordContent keywordContent = KeywordContent.builder()
+          .keyword(testKeyword)
+          .content(testContent)
+          .score(0.8)
           .build();
 
-      Content dramaMovie = Content.builder()
+      when(keywordContentRepository.findByKeywordIdWithPagination(
+          eq(keywordId), isNull(), isNull(), eq(11)))
+          .thenReturn(List.of(keywordContent));
+      when(keywordContentRepository.countByKeywordId(keywordId))
+          .thenReturn(1L);
+
+      // when
+      CursorPageResponseDto<ContentDto> result = curationService
+          .getRecommendationsByKeyword(keywordId, userId, request);
+
+      // then
+      assertNotNull(result);
+      assertEquals(1, result.data().size());
+      assertEquals(1L, result.totalElements());
+      assertFalse(result.hasNext());
+      assertNull(result.nextCursor());
+
+      ContentDto contentDto = result.data().get(0);
+      assertEquals(testContent.getId(), contentDto.id());
+      assertEquals(testContent.getTitle(), contentDto.title());
+    }
+
+    @Test
+    @DisplayName("키워드가 존재하지 않을 때 예외 발생")
+    void getRecommendations_KeywordNotFound() {
+      // given
+      CursorPageRequest request = new CursorPageRequest(null, 10);
+      when(keywordRepository.findByIdAndUserId(keywordId, userId))
+          .thenReturn(Optional.empty());
+
+      // when & then
+      assertThrows(KeywordNotFoundException.class, () -> {
+        curationService.getRecommendationsByKeyword(keywordId, userId, request);
+      });
+
+      verify(keywordRepository).findByIdAndUserId(keywordId, userId);
+    }
+
+    @Test
+    @DisplayName("잘못된 페이지 크기로 요청 시 예외 발생")
+    void getRecommendations_InvalidPageSize() {
+      // given
+      CursorPageRequest request = new CursorPageRequest(null, 0);
+
+      // when & then
+      assertThrows(InvalidPageSizeException.class, () -> {
+        curationService.getRecommendationsByKeyword(keywordId, userId, request);
+      });
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 너무 클 때 예외 발생")
+    void getRecommendations_PageSizeTooLarge() {
+      // given
+      CursorPageRequest request = new CursorPageRequest(null, 100);
+
+      // when & then
+      assertThrows(InvalidPageSizeException.class, () -> {
+        curationService.getRecommendationsByKeyword(keywordId, userId, request);
+      });
+    }
+
+    @Test
+    @DisplayName("점수가 계산되지 않은 경우 빈 결과 반환")
+    void getRecommendations_NoScoresCalculated() {
+      // given
+      CursorPageRequest request = new CursorPageRequest(null, 10);
+
+      when(keywordRepository.findByIdAndUserId(keywordId, userId))
+          .thenReturn(Optional.of(testKeyword));
+      when(keywordContentRepository.existsByKeywordId(keywordId))
+          .thenReturn(false);
+
+      // when
+      CursorPageResponseDto<ContentDto> result = curationService
+          .getRecommendationsByKeyword(keywordId, userId, request);
+
+      // then
+      assertNotNull(result);
+      assertTrue(result.data().isEmpty());
+      assertEquals(0, result.size());
+      assertEquals(0L, result.totalElements());
+      assertFalse(result.hasNext());
+      assertNull(result.nextCursor());
+    }
+
+    @Test
+    @DisplayName("잘못된 커서 형식으로 요청 시 예외 발생")
+    void getRecommendations_InvalidCursor() {
+      // given
+      CursorPageRequest request = new CursorPageRequest("invalid-cursor", 10);
+
+      when(keywordRepository.findByIdAndUserId(keywordId, userId))
+          .thenReturn(Optional.of(testKeyword));
+      when(keywordContentRepository.existsByKeywordId(keywordId))
+          .thenReturn(true);
+
+      // when & then
+      assertThrows(InvalidCursorFormatException.class, () -> {
+        curationService.getRecommendationsByKeyword(keywordId, userId, request);
+      });
+    }
+
+    @Test
+    @DisplayName("페이지네이션 with hasNext")
+    void getRecommendations_WithPagination() {
+      // given
+      CursorPageRequest request = new CursorPageRequest(null, 1);
+
+      when(keywordRepository.findByIdAndUserId(keywordId, userId))
+          .thenReturn(Optional.of(testKeyword));
+      when(keywordContentRepository.existsByKeywordId(keywordId))
+          .thenReturn(true);
+
+      Content content2 = Content.builder()
           .id(UUID.randomUUID())
-          .title("감동 드라마")
-          .description("가족 이야기")
+          .title("액션 영화 2")
+          .description("두 번째 액션 영화")
           .contentType(ContentType.MOVIE)
           .avgRating(BigDecimal.valueOf(4.0))
           .build();
 
-      when(contentRepository.findAll()).thenReturn(List.of(actionMovie, dramaMovie));
-      when(keywordContentRepository.save(any(KeywordContent.class))).thenReturn(new KeywordContent(keyword, actionMovie));
-
-      // when
-      List<ContentDto> result = curationService.curateContentForKeyword(keyword);
-
-      // then
-      assertNotNull(result);
-      // 액션 관련 콘텐츠가 포함되어야 함
-      assertTrue(result.stream().anyMatch(c -> c.title().contains("액션")));
-    }
-
-    @Test
-    @DisplayName("매칭되는 콘텐츠가 없는 경우")
-    void noMatchingContent() {
-      // given
-      Content unrelatedContent = Content.builder()
-          .id(UUID.randomUUID())
-          .title("로맨틱 코미디")
-          .description("사랑 이야기")
-          .contentType(ContentType.MOVIE)
-          .avgRating(BigDecimal.valueOf(3.0))
+      KeywordContent keywordContent1 = KeywordContent.builder()
+          .keyword(testKeyword)
+          .content(testContent)
+          .score(0.9)
           .build();
 
-      when(contentRepository.findAll()).thenReturn(List.of(unrelatedContent));
+      KeywordContent keywordContent2 = KeywordContent.builder()
+          .keyword(testKeyword)
+          .content(content2)
+          .score(0.8)
+          .build();
+
+      when(keywordContentRepository.findByKeywordIdWithPagination(
+          eq(keywordId), isNull(), isNull(), eq(2)))
+          .thenReturn(List.of(keywordContent1, keywordContent2));
+      when(keywordContentRepository.countByKeywordId(keywordId))
+          .thenReturn(2L);
 
       // when
-      List<ContentDto> result = curationService.curateContentForKeyword(keyword);
+      CursorPageResponseDto<ContentDto> result = curationService
+          .getRecommendationsByKeyword(keywordId, userId, request);
 
       // then
       assertNotNull(result);
-      // 임계값 이하의 콘텐츠는 포함되지 않을 수 있음
-      verify(contentRepository, times(1)).findAll();
+      assertEquals(1, result.data().size());
+      assertEquals(2L, result.totalElements());
+      assertTrue(result.hasNext());
+      assertNotNull(result.nextCursor());
     }
   }
 
   @Nested
-  @DisplayName("사용자 추천 콘텐츠 조회")
-  class GetRecommendationsByKeyword {
+  @DisplayName("사용자별 키워드 조회 테스트")
+  class GetKeywordsByUserTest {
 
     @Test
-    @DisplayName("성공")
-    void success() {
+    @DisplayName("성공적인 사용자 키워드 조회")
+    void getKeywordsByUser_Success() {
       // given
-      Keyword testKeyword = Keyword.builder()
-          .id(keywordId)
-          .user(user)
-          .keyword("테스트키워드")
-          .build();
-
-      Content testContent = Content.builder()
-          .id(UUID.randomUUID())
-          .title("테스트 콘텐츠")
-          .description("테스트 설명")
-          .contentType(ContentType.MOVIE)
-          .avgRating(BigDecimal.valueOf(4.5))
-          .build();
-
-      KeywordContent keywordContent = new KeywordContent(testKeyword, testContent);
-
-      when(keywordRepository.findByIdAndUserId(keywordId, userId)).thenReturn(Optional.of(testKeyword));
-      when(keywordContentRepository.findByKeywordId(keywordId)).thenReturn(List.of(keywordContent));
+      when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+      when(keywordRepository.findAllByUserId(userId)).thenReturn(List.of(testKeyword));
 
       // when
-      List<ContentDto> result = curationService.getRecommendationsByKeyword(keywordId, userId);
+      List<KeywordDto> result = curationService.getKeywordsByUser(userId);
 
       // then
       assertNotNull(result);
       assertEquals(1, result.size());
-      assertEquals(testContent.getTitle(), result.get(0).title());
+      assertEquals(testKeyword.getKeyword(), result.get(0).keyword());
 
-      verify(keywordRepository, times(1)).findByIdAndUserId(keywordId, userId);
-      verify(keywordContentRepository, times(1)).findByKeywordId(keywordId);
+      verify(userRepository).findById(userId);
+      verify(keywordRepository).findAllByUserId(userId);
     }
 
     @Test
-    @DisplayName("키워드를 찾을 수 없는 경우 예외 발생")
-    void keywordNotFound() {
+    @DisplayName("존재하지 않는 사용자로 키워드 조회 시 예외 발생")
+    void getKeywordsByUser_UserNotFound() {
       // given
-      when(keywordRepository.findByIdAndUserId(keywordId, userId)).thenReturn(Optional.empty());
+      when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
       // when & then
-      assertThrows(KeywordNotFoundException.class, () -> {
-        curationService.getRecommendationsByKeyword(keywordId, userId);
+      assertThrows(UserNotFoundException.class, () -> {
+        curationService.getKeywordsByUser(userId);
       });
 
-      verify(keywordRepository, times(1)).findByIdAndUserId(keywordId, userId);
-      verify(keywordContentRepository, never()).findByKeywordId(any());
+      verify(userRepository).findById(userId);
+      verify(keywordRepository, never()).findAllByUserId(any());
     }
 
     @Test
-    @DisplayName("키워드는 존재하지만 매칭된 콘텐츠가 없는 경우")
-    void noMatchingContents() {
+    @DisplayName("키워드가 없는 사용자의 빈 목록 반환")
+    void getKeywordsByUser_EmptyList() {
       // given
-      Keyword testKeyword = Keyword.builder()
-          .id(keywordId)
-          .user(user)
-          .keyword("테스트키워드")
-          .build();
-
-      when(keywordRepository.findByIdAndUserId(keywordId, userId)).thenReturn(Optional.of(testKeyword));
-      when(keywordContentRepository.findByKeywordId(keywordId)).thenReturn(List.of()); // 빈 리스트
+      when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+      when(keywordRepository.findAllByUserId(userId)).thenReturn(List.of());
 
       // when
-      List<ContentDto> result = curationService.getRecommendationsByKeyword(keywordId, userId);
+      List<KeywordDto> result = curationService.getKeywordsByUser(userId);
 
       // then
       assertNotNull(result);
       assertTrue(result.isEmpty());
 
-      verify(keywordRepository, times(1)).findByIdAndUserId(keywordId, userId);
-      verify(keywordContentRepository, times(1)).findByKeywordId(keywordId);
+      verify(userRepository).findById(userId);
+      verify(keywordRepository).findAllByUserId(userId);
     }
+  }
+
+  @Nested
+  @DisplayName("키워드 삭제 테스트")
+  class DeleteKeywordTest {
 
     @Test
-    @DisplayName("다른 사용자의 키워드에 접근하는 경우 예외 발생")
-    void accessOtherUserKeyword() {
+    @DisplayName("성공적인 키워드 삭제")
+    void deleteKeyword_Success() {
       // given
-      UUID otherUserId = UUID.randomUUID();
-      when(keywordRepository.findByIdAndUserId(keywordId, otherUserId)).thenReturn(Optional.empty());
+      when(keywordRepository.findById(keywordId)).thenReturn(Optional.of(testKeyword));
 
-      // when & then
-      assertThrows(KeywordNotFoundException.class, () -> {
-        curationService.getRecommendationsByKeyword(keywordId, otherUserId);
+      // when
+      assertDoesNotThrow(() -> {
+        curationService.delete(keywordId, userId);
       });
 
-      verify(keywordRepository, times(1)).findByIdAndUserId(keywordId, otherUserId);
-    }
-  }
-
-  @Nested
-  @DisplayName("신규 콘텐츠 배치 큐레이션")
-  class BatchCurationForNewContents {
-
-    @Test
-    @DisplayName("성공")
-    void success() {
-      // given
-      List<Content> newContents = List.of(content);
-
-      when(keywordRepository.findAll()).thenReturn(List.of(keyword));
-      when(keywordContentRepository.existsByKeywordIdAndContentId(any(), any())).thenReturn(false);
-      when(keywordContentRepository.save(any(KeywordContent.class))).thenReturn(new KeywordContent(keyword, content));
-
-      // when
-      curationService.batchCurationForNewContents(newContents);
-
       // then
-      verify(keywordRepository, times(1)).findAll();
-      // 점수가 임계값(0.25)을 넘으면 저장되어야 함
+      verify(keywordRepository).findById(keywordId);
+      verify(keywordRepository).delete(testKeyword);
     }
 
     @Test
-    @DisplayName("이미 존재하는 키워드-콘텐츠 관계")
-    void alreadyExistingRelation() {
-      // given
-      List<Content> newContents = List.of(content);
-
-      when(keywordRepository.findAll()).thenReturn(List.of(keyword));
-      when(keywordContentRepository.existsByKeywordIdAndContentId(keywordId, contentId)).thenReturn(true);
-
-      // when
-      curationService.batchCurationForNewContents(newContents);
-
-      // then
-      verify(keywordRepository, times(1)).findAll();
-      verify(keywordContentRepository, never()).save(any(KeywordContent.class));
-    }
-
-    @Test
-    @DisplayName("빈 콘텐츠 리스트")
-    void emptyContentList() {
-      // given
-      List<Content> newContents = List.of();
-
-      when(keywordRepository.findAll()).thenReturn(List.of(keyword));
-
-      // when
-      curationService.batchCurationForNewContents(newContents);
-
-      // then
-      verify(keywordRepository, times(1)).findAll();
-      verify(keywordContentRepository, never()).save(any(KeywordContent.class));
-    }
-  }
-
-  @Nested
-  @DisplayName("콘텐츠 평점 업데이트")
-  class UpdateContentRating {
-
-    @Test
-    @DisplayName("성공")
-    void success() {
-      // given
-      UUID reviewId1 = UUID.randomUUID();
-      UUID reviewId2 = UUID.randomUUID();
-      UUID authorId = UUID.randomUUID();
-      String authorName = "테스트사용자";
-
-      ReviewDto review1 = new ReviewDto(
-          reviewId1,
-          authorId,
-          authorName,
-          "좋은 영화",
-          "재미있어요",
-          LocalDateTime.now(),
-          BigDecimal.valueOf(5)
-      );
-
-      ReviewDto review2 = new ReviewDto(
-          reviewId2,
-          authorId,
-          authorName,
-          "괜찮은 영화",
-          "보통이에요",
-          LocalDateTime.now(),
-          BigDecimal.valueOf(3)
-      );
-
-      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
-      when(reviewService.getAllByContent(contentId)).thenReturn(List.of(review1, review2));
-      when(contentRepository.save(any(Content.class))).thenReturn(content);
-
-      // when
-      curationService.updateContentRating(contentId);
-
-      // then
-      verify(contentRepository, times(1)).findById(contentId);
-      verify(reviewService, times(1)).getAllByContent(contentId);
-      verify(contentRepository, times(1)).save(any(Content.class));
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 콘텐츠")
-    void failsWhenContentNotFound() {
-      // given
-      UUID randomContentId = UUID.randomUUID();
-
-      when(contentRepository.findById(randomContentId)).thenReturn(Optional.empty());
-
-      // when
-      curationService.updateContentRating(randomContentId);
-
-      // then
-      verify(contentRepository, times(1)).findById(randomContentId);
-      verify(contentRepository, never()).save(any(Content.class));
-      verify(reviewService, never()).getAllByContent(any());
-    }
-
-    @Test
-    @DisplayName("리뷰가 없는 경우")
-    void noReviews() {
-      // given
-      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
-      when(reviewService.getAllByContent(contentId)).thenReturn(List.of());
-      when(contentRepository.save(any(Content.class))).thenReturn(content);
-
-      // when
-      curationService.updateContentRating(contentId);
-
-      // then
-      verify(contentRepository, times(1)).findById(contentId);
-      verify(reviewService, times(1)).getAllByContent(contentId);
-      verify(contentRepository, times(1)).save(any(Content.class));
-    }
-
-    @Test
-    @DisplayName("평점이 null인 리뷰가 포함된 경우")
-    void reviewsWithNullRating() {
-      // given
-      UUID reviewId1 = UUID.randomUUID();
-      UUID reviewId2 = UUID.randomUUID();
-      UUID authorId = UUID.randomUUID();
-      String authorName = "테스트사용자";
-
-      ReviewDto reviewWithNullRating = new ReviewDto(
-          reviewId1,
-          authorId,
-          authorName,
-          "평점 없는 리뷰",
-          "평점을 주지 않았어요",
-          LocalDateTime.now(),
-          null
-      );
-
-      ReviewDto normalReview = new ReviewDto(
-          reviewId2,
-          authorId,
-          authorName,
-          "일반 리뷰",
-          "좋아요",
-          LocalDateTime.now(),
-          BigDecimal.valueOf(4)
-      );
-
-      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
-      when(reviewService.getAllByContent(contentId)).thenReturn(List.of(reviewWithNullRating, normalReview));
-      when(contentRepository.save(any(Content.class))).thenReturn(content);
-
-      // when
-      curationService.updateContentRating(contentId);
-
-      // then
-      verify(contentRepository, times(1)).findById(contentId);
-      verify(reviewService, times(1)).getAllByContent(contentId);
-      verify(contentRepository, times(1)).save(any(Content.class));
-    }
-  }
-
-  @Nested
-  @DisplayName("키워드 삭제")
-  class DeleteKeyword {
-
-    @Test
-    @DisplayName("성공")
-    void success() {
-      // given
-      when(keywordRepository.findById(keywordId)).thenReturn(Optional.of(keyword));
-
-      // when
-      curationService.delete(keywordId, userId);
-
-      // then
-      verify(keywordRepository, times(1)).findById(keywordId);
-      verify(keywordRepository, times(1)).delete(keyword);
-    }
-
-    @Test
-    @DisplayName("키워드를 찾을 수 없는 경우")
-    void keywordNotFound() {
+    @DisplayName("존재하지 않는 키워드 삭제 시 예외 발생")
+    void deleteKeyword_KeywordNotFound() {
       // given
       when(keywordRepository.findById(keywordId)).thenReturn(Optional.empty());
 
@@ -522,38 +431,224 @@ class CurationServiceImplTest {
         curationService.delete(keywordId, userId);
       });
 
-      verify(keywordRepository, times(1)).findById(keywordId);
+      verify(keywordRepository).findById(keywordId);
       verify(keywordRepository, never()).delete(any());
     }
 
     @Test
-    @DisplayName("다른 사용자의 키워드 삭제 시도")
-    void deleteOtherUserKeyword() {
+    @DisplayName("다른 사용자의 키워드 삭제 시 예외 발생")
+    void deleteKeyword_UnauthorizedUser() {
       // given
       UUID otherUserId = UUID.randomUUID();
-      User otherUser = User.builder()
-          .id(otherUserId)
-          .name("다른유저")
-          .email("other@test.com")
-          .password("test")
-          .role(Role.USER)
-          .build();
-
-      Keyword otherUserKeyword = Keyword.builder()
-          .id(keywordId)
-          .user(otherUser)
-          .keyword("액션")
-          .build();
-
-      when(keywordRepository.findById(keywordId)).thenReturn(Optional.of(otherUserKeyword));
+      when(keywordRepository.findById(keywordId)).thenReturn(Optional.of(testKeyword));
 
       // when & then
-      assertThrows(team03.mopl.common.exception.curation.KeywordDeleteDeniedException.class, () -> {
-        curationService.delete(keywordId, userId);
+      assertThrows(KeywordDeleteDeniedException.class, () -> {
+        curationService.delete(keywordId, otherUserId);
       });
 
-      verify(keywordRepository, times(1)).findById(keywordId);
+      verify(keywordRepository).findById(keywordId);
       verify(keywordRepository, never()).delete(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("콘텐츠 평점 업데이트 테스트")
+  class UpdateContentRatingTest {
+
+    @DisplayName("성공적인 콘텐츠 평점 업데이트")
+    @Test
+    void updateContentRating_Success() {
+
+      // given
+      UUID contentId = UUID.randomUUID();
+      Content content = Content.builder()
+          .id(contentId)
+          .title("액션 영화")
+          .description("액션 영화입니다")
+          .contentType(ContentType.MOVIE)
+          .avgRating(BigDecimal.valueOf(3.0))
+          .build();
+
+      List<ReviewDto> reviews = List.of(
+          new ReviewDto(UUID.randomUUID(), UUID.randomUUID(), "사용자1", "좋은 영화", null,
+              LocalDateTime.now(), BigDecimal.valueOf(4.0)),
+          new ReviewDto(UUID.randomUUID(), UUID.randomUUID(), "사용자2",
+              "최고의 영화", null, LocalDateTime.now(), BigDecimal.valueOf(5.0))
+      );
+
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+      when(reviewService.getAllByContent(contentId)).thenReturn(reviews);
+
+      // when
+      curationService.updateContentRating(contentId);
+
+      // then
+      verify(contentRepository, times(1)).findById(contentId);
+      verify(reviewService, times(1)).getAllByContent(contentId);
+      verify(contentRepository, times(1)).save(content);
+
+      // 평점이 올바르게 계산되었는지 확인 (4.0 + 5.0) / 2 = 4.5
+      assertEquals(BigDecimal.valueOf(4.50).setScale(2), content.getAvgRating());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 콘텐츠 평점 업데이트 시 예외 발생")
+    void updateContentRating_ContentNotFound() {
+      // given
+      when(contentRepository.findById(contentId)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThrows(ContentNotFoundException.class, () -> {
+        curationService.updateContentRating(contentId);
+      });
+
+      verify(contentRepository).findById(contentId);
+      verify(reviewService, never()).getAllByContent(any());
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 콘텐츠의 평점 업데이트")
+    void updateContentRating_NoReviews() {
+      // given
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(testContent));
+      when(reviewService.getAllByContent(contentId)).thenReturn(List.of());
+      when(contentRepository.save(any(Content.class))).thenReturn(testContent);
+
+      // when
+      assertDoesNotThrow(() -> {
+        curationService.updateContentRating(contentId);
+      });
+
+      // then
+      verify(contentRepository).findById(contentId);
+      verify(reviewService).getAllByContent(contentId);
+      verify(contentRepository).save(any(Content.class));
+    }
+
+    @Test
+    @DisplayName("리뷰 서비스 예외 발생 시 ContentRatingUpdateException 발생")
+    void updateContentRating_ReviewServiceException() {
+      // given
+      UUID contentId = UUID.randomUUID();
+      Content content = Content.builder()
+          .id(contentId)
+          .title("액션 영화")
+          .description("액션 영화입니다")
+          .contentType(ContentType.MOVIE)
+          .avgRating(BigDecimal.valueOf(4.5))
+          .build();
+
+      when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
+
+      // reviewService.getAllByContent()에서 예외 발생 시키기
+      when(reviewService.getAllByContent(contentId))
+          .thenThrow(new RuntimeException("Review service error"));
+
+      // when & then
+      ContentRatingUpdateException exception = assertThrows(ContentRatingUpdateException.class,
+          () -> {
+            curationService.updateContentRating(contentId);
+          });
+
+      verify(contentRepository, times(1)).findById(contentId);
+      verify(reviewService, times(1)).getAllByContent(contentId);
+      // save는 호출되지 않아야 함 (예외 발생으로 인해)
+      verify(contentRepository, never()).save(any(Content.class));
+    }
+
+    @Nested
+    @DisplayName("신규 콘텐츠 배치 큐레이션 테스트")
+    class BatchCurationTest {
+
+      @Test
+      @DisplayName("성공적인 신규 콘텐츠 배치 큐레이션")
+      void batchCurationForNewContents_Success() {
+        // given
+        List<Content> newContents = List.of(testContent);
+        when(keywordRepository.findAll()).thenReturn(List.of(testKeyword));
+        when(keywordContentRepository.existsByKeywordIdAndContentId(keywordId, contentId))
+            .thenReturn(false);
+        when(keywordContentRepository.save(any(KeywordContent.class)))
+            .thenReturn(mock(KeywordContent.class));
+
+        // when
+        assertDoesNotThrow(() -> {
+          curationService.batchCurationForNewContents(newContents);
+        });
+
+        // then
+        verify(keywordRepository).findAll();
+        verify(keywordContentRepository).existsByKeywordIdAndContentId(keywordId, contentId);
+        verify(keywordContentRepository).save(any(KeywordContent.class));
+      }
+
+      @Test
+      @DisplayName("빈 콘텐츠 목록으로 배치 큐레이션")
+      void batchCurationForNewContents_EmptyContents() {
+        // given
+        List<Content> newContents = List.of();
+
+        // when
+        assertDoesNotThrow(() -> {
+          curationService.batchCurationForNewContents(newContents);
+        });
+
+        // then
+        verify(keywordRepository, never()).findAll();
+        verify(keywordContentRepository, never()).save(any());
+      }
+
+      @Test
+      @DisplayName("키워드가 없을 때 배치 큐레이션")
+      void batchCurationForNewContents_NoKeywords() {
+        // given
+        List<Content> newContents = List.of(testContent);
+        when(keywordRepository.findAll()).thenReturn(List.of());
+
+        // when
+        assertDoesNotThrow(() -> {
+          curationService.batchCurationForNewContents(newContents);
+        });
+
+        // then
+        verify(keywordRepository).findAll();
+        verify(keywordContentRepository, never()).save(any());
+      }
+
+      @Test
+      @DisplayName("이미 존재하는 키워드-콘텐츠 매칭 건너뛰기")
+      void batchCurationForNewContents_ExistingMatch() {
+        // given
+        List<Content> newContents = List.of(testContent);
+        when(keywordRepository.findAll()).thenReturn(List.of(testKeyword));
+        when(keywordContentRepository.existsByKeywordIdAndContentId(keywordId, contentId))
+            .thenReturn(true);
+
+        // when
+        assertDoesNotThrow(() -> {
+          curationService.batchCurationForNewContents(newContents);
+        });
+
+        // then
+        verify(keywordRepository).findAll();
+        verify(keywordContentRepository).existsByKeywordIdAndContentId(keywordId, contentId);
+        verify(keywordContentRepository, never()).save(any());
+      }
+    }
+
+    @Nested
+    @DisplayName("초기화 테스트")
+    class InitializationTest {
+
+      @Test
+      @DisplayName("서비스 초기화 성공")
+      void init_Success() {
+        // when & then
+        assertDoesNotThrow(() -> {
+          curationService.init();
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #184 

Close #184 

## 🪐 작업 내용
1. curation에 cursor pagination 추가
2. 콘텐츠 데이터 적재 작업 후 큐레이션 처리하도록 event listener 생성
3. keyword와의 점수 계산 비동기 처리

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?