### PR TITLE
refactor: asyncConfig 수정

### DIFF
--- a/src/main/java/team03/mopl/common/config/AsyncConfig.java
+++ b/src/main/java/team03/mopl/common/config/AsyncConfig.java
@@ -4,18 +4,17 @@ import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
 @Slf4j
-public class AsyncConfig implements AsyncConfigurer {
+public class AsyncConfig {
 
-  @Override
   @Bean(name = "notificationExecutor")
-  public ThreadPoolTaskExecutor getAsyncExecutor() {
+  public TaskExecutor getAsyncExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(4);
     executor.setMaxPoolSize(10);
@@ -23,6 +22,18 @@ public class AsyncConfig implements AsyncConfigurer {
     //생성되는 스레드 이름의 prefix를 지정합니다.
     executor.setThreadNamePrefix("async-notification-");
     // 포화 시 호출자 스레드에서 실행
+    executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+    executor.initialize();
+    return executor;
+  }
+
+  @Bean("scoreCalculationExecutor")
+  public TaskExecutor scoreCalculationExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(4);
+    executor.setQueueCapacity(10);
+    executor.setThreadNamePrefix("ScoreCalc-");
     executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
     executor.initialize();
     return executor;


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->

## 🪐 작업 내용
- scoreCalculationExecutor() 추가
- AsyncConfigurer 삭제
  - AsyncConfigurer 사용하는 경우:
    - 모든 @Async에 대한 기본 설정을 통일하고 싶을 때
    - 전역 예외 처리를 설정하고 싶을 때
  - Bean 방식 사용하는 경우:
    - 용도별로 다른 executor를 사용하고 싶을 때
    - 명시적으로 executor를 지정하고 싶을 때

  -> Bean 방식으로 수정
- ThreadPoolTaskExecutor는 TaskExecutor의 구현체이기 때문에 반환값을 TaskExecutor로 변경

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?