### PR TITLE
refactor: 리뷰 생성, 수정, 삭제 시 content avgRating 점수 계산 event 생성

### DIFF
--- a/src/main/java/team03/mopl/domain/review/entity/ReviewEvent.java
+++ b/src/main/java/team03/mopl/domain/review/entity/ReviewEvent.java
@@ -1,0 +1,24 @@
+package team03.mopl.domain.review.entity;
+
+import java.util.UUID;
+
+public record ReviewEvent(
+    UUID contentId,
+    EventType eventType
+) {
+  public enum EventType {
+    CREATED, UPDATED, DELETED
+  }
+
+  public static ReviewEvent created(UUID contentId) {
+    return new ReviewEvent(contentId, EventType.CREATED);
+  }
+
+  public static ReviewEvent updated(UUID contentId) {
+    return new ReviewEvent(contentId, EventType.UPDATED);
+  }
+
+  public static ReviewEvent deleted(UUID contentId) {
+    return new ReviewEvent(contentId, EventType.DELETED);
+  }
+}

--- a/src/main/java/team03/mopl/domain/review/event/ReviewEvent.java
+++ b/src/main/java/team03/mopl/domain/review/event/ReviewEvent.java
@@ -1,4 +1,4 @@
-package team03.mopl.domain.review.entity;
+package team03.mopl.domain.review.event;
 
 import java.util.UUID;
 

--- a/src/main/java/team03/mopl/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/team03/mopl/domain/review/event/ReviewEventHandler.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import team03.mopl.domain.content.service.ContentService;
-import team03.mopl.domain.review.entity.ReviewEvent;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/team03/mopl/domain/review/event/ReviewEventHandler.java
+++ b/src/main/java/team03/mopl/domain/review/event/ReviewEventHandler.java
@@ -1,0 +1,19 @@
+package team03.mopl.domain.review.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team03.mopl.domain.content.service.ContentService;
+import team03.mopl.domain.review.entity.ReviewEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewEventHandler {
+
+  private final ContentService contentService;
+
+  @EventListener
+  public void handleReviewEvent(ReviewEvent event) {
+    contentService.updateContentRating(event.contentId());
+  }
+}

--- a/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
@@ -17,7 +17,7 @@ import team03.mopl.domain.review.dto.ReviewCreateRequest;
 import team03.mopl.domain.review.dto.ReviewDto;
 import team03.mopl.domain.review.dto.ReviewUpdateRequest;
 import team03.mopl.domain.review.entity.Review;
-import team03.mopl.domain.review.entity.ReviewEvent;
+import team03.mopl.domain.review.event.ReviewEvent;
 import team03.mopl.domain.review.repository.ReviewRepository;
 import team03.mopl.domain.user.User;
 import team03.mopl.domain.user.UserRepository;

--- a/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
@@ -4,9 +4,9 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import team03.mopl.common.exception.content.ContentNotFoundException;
-import team03.mopl.common.exception.review.DuplicateReviewException;
 import team03.mopl.common.exception.review.ReviewDeleteDeniedException;
 import team03.mopl.common.exception.review.ReviewNotFoundException;
 import team03.mopl.common.exception.review.ReviewUpdateDeniedException;
@@ -17,6 +17,7 @@ import team03.mopl.domain.review.dto.ReviewCreateRequest;
 import team03.mopl.domain.review.dto.ReviewDto;
 import team03.mopl.domain.review.dto.ReviewUpdateRequest;
 import team03.mopl.domain.review.entity.Review;
+import team03.mopl.domain.review.entity.ReviewEvent;
 import team03.mopl.domain.review.repository.ReviewRepository;
 import team03.mopl.domain.user.User;
 import team03.mopl.domain.user.UserRepository;
@@ -29,28 +30,22 @@ public class ReviewServiceImpl implements ReviewService {
   private final ReviewRepository reviewRepository;
   private final UserRepository userRepository;
   private final ContentRepository contentRepository;
+  private final ApplicationEventPublisher applicationEventPublisher;
 
   @Override
   public ReviewDto create(ReviewCreateRequest request) {
+    User user = userRepository.findById(request.userId())
+        .orElseThrow(() -> {
+          log.warn("존재하지 않는 유저입니다. 유저 ID: {}", request.userId());
+          return new UserNotFoundException();
+        });
 
-    if (!userRepository.existsById(request.userId())) {
-      log.warn("존재하지 않는 유저입니다. 유저 ID: ", request.userId());
-      throw new UserNotFoundException();
-    }
+    Content content = contentRepository.findById(request.contentId())
+        .orElseThrow(() -> {
+          log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: {}", request.contentId());
+          return new ContentNotFoundException();
+        });
 
-    if (!contentRepository.existsById(request.contentId())) {
-      log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: ", request.contentId());
-      throw new ContentNotFoundException();
-    }
-
-    if (reviewRepository.existsByUserIdAndContentId(request.userId(), request.contentId())) {
-      log.warn("이미 리뷰를 작성한 콘텐츠입니다. 유저 ID: {}, 콘텐츠 ID: {}",
-          request.userId(), request.contentId());
-      throw new DuplicateReviewException();
-    }
-
-    User user = userRepository.findById(request.userId()).orElseThrow(UserNotFoundException::new);
-    Content content = contentRepository.findById(request.contentId()).orElseThrow(ContentNotFoundException::new);
     Review review = Review.builder()
         .user(user)
         .content(content)
@@ -58,32 +53,47 @@ public class ReviewServiceImpl implements ReviewService {
         .comment(request.comment())
         .rating(request.rating())
         .build();
-    return ReviewDto.from(reviewRepository.save(review));
+
+    Review savedReview = reviewRepository.save(review);
+
+    applicationEventPublisher.publishEvent(
+        ReviewEvent.created(savedReview.getContent().getId()));
+
+    return ReviewDto.from(savedReview);
   }
 
   @Override
   public ReviewDto update(UUID reviewId, ReviewUpdateRequest request, UUID userId) {
-    Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(ReviewNotFoundException::new);
+
     if (!review.getUser().getId().equals(userId)) {
-      log.warn("리뷰 작성자만 수정할 수 있습니다. 리뷰 작성자 ID: ", userId);
+      log.warn("리뷰 작성자만 수정할 수 있습니다. 요청 유저 ID: {}, 리뷰 작성자 ID: {}",
+          userId, review.getUser().getId());
       throw new ReviewUpdateDeniedException();
     }
 
     review.update(request.title(), request.comment(), request.rating());
-    return ReviewDto.from(reviewRepository.save(review));
+    Review savedReview = reviewRepository.save(review);
+
+    applicationEventPublisher.publishEvent(
+        ReviewEvent.updated(savedReview.getContent().getId())
+    );
+
+    return ReviewDto.from(savedReview);
   }
 
   @Override
   public ReviewDto get(UUID reviewId) {
-    Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
-
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(ReviewNotFoundException::new);
     return ReviewDto.from(review);
   }
 
   @Override
   public List<ReviewDto> getAllByUser(UUID userId) {
     if (!userRepository.existsById(userId)) {
-      log.warn("존재하지 않는 유저입니다. 유저 ID: ", userId);
+      log.warn("존재하지 않는 유저입니다. 유저 ID: {}", userId);
       throw new UserNotFoundException();
     }
 
@@ -94,7 +104,7 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   public List<ReviewDto> getAllByContent(UUID contentId) {
     if (!contentRepository.existsById(contentId)) {
-      log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: ", contentId);
+      log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: {}", contentId);
       throw new ContentNotFoundException();
     }
 
@@ -104,12 +114,21 @@ public class ReviewServiceImpl implements ReviewService {
 
   @Override
   public void delete(UUID reviewId, UUID userId) {
-    Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(ReviewNotFoundException::new);
+
     if (!review.getUser().getId().equals(userId)) {
-      log.warn("리뷰 작성자만 삭제할 수 있습니다. 리뷰 작성자 ID: ", userId);
+      log.warn("리뷰 작성자만 삭제할 수 있습니다. 요청 유저 ID: {}, 리뷰 작성자 ID: {}",
+          userId, review.getUser().getId());
       throw new ReviewDeleteDeniedException();
     }
 
+    UUID contentId = review.getContent().getId(); // 삭제 전에 contentId 저장
     reviewRepository.delete(review);
+
+    // 삭제 완료 후 이벤트 발행
+    applicationEventPublisher.publishEvent(
+        ReviewEvent.deleted(contentId)
+    );
   }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
- #194 

Close #194 

## 🪐 작업 내용
- review create, update, delete 시 content의 평균 평점 자동으로 계산하도록 event 생성

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?