### PR TITLE
fix: 시청방 정보 DTO에 ContentDto 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomInfoDto.java
+++ b/src/main/java/team03/mopl/domain/watchroom/dto/WatchRoomInfoDto.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.watchroom.dto;
 
 import java.util.UUID;
 import lombok.Builder;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.watchroom.dto.participant.ParticipantsInfoDto;
 
 @Builder
@@ -9,9 +10,7 @@ public record WatchRoomInfoDto (
     UUID id,
     String title,
     UUID newUserId,
-    String contentTitle,
-    String contentUrl,
-    ParticipantsInfoDto participantsInfoDto
-){
+    ParticipantsInfoDto participantsInfoDto,
+    ContentDto content){
 
 }

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -14,6 +14,7 @@ import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomContentWithParticipantCountDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomCreateRequest;
 import team03.mopl.domain.watchroom.dto.WatchRoomDto;
@@ -255,8 +256,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
     return WatchRoomInfoDto.builder()
         .id(watchRoom.getId())
         .newUserId(user.getId())
-        .contentTitle(watchRoom.getContent().getTitle())
-        .contentUrl(watchRoom.getContent().getYoutubeUrl())
+        .content(ContentDto.from(watchRoom.getContent()))
         .participantsInfoDto(getParticipantsInfoDto(watchRoom))
         .build();
   }
@@ -266,8 +266,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     return WatchRoomInfoDto.builder()
         .id(watchRoom.getId())
-        .contentTitle(watchRoom.getContent().getTitle())
-        .contentUrl(watchRoom.getContent().getYoutubeUrl())
+        .content(ContentDto.from(watchRoom.getContent()))
         .participantsInfoDto(getParticipantsInfoDto(watchRoom))
         .build();
   }

--- a/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
@@ -30,6 +30,7 @@ import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomContentWithParticipantCountDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomCreateRequest;
 import team03.mopl.domain.watchroom.dto.WatchRoomDto;
@@ -543,7 +544,7 @@ class WatchRoomServiceImplTest {
 
       WatchRoomInfoDto expected = WatchRoomInfoDto.builder()
           .id(chatRoomId)
-          .contentTitle(watchRoom.getContent().getTitle())
+          .content(ContentDto.from(content))
           .participantsInfoDto(participantsInfoDto)
           .build();
 
@@ -560,7 +561,7 @@ class WatchRoomServiceImplTest {
           .joinWatchRoomAndGetInfo(chatRoomId, participant.getEmail());
 
       assertEquals(expected.id(), watchRoomInfoDto.id());
-      assertEquals(expected.contentTitle(), watchRoomInfoDto.contentTitle());
+      assertEquals(expected.content().title(), watchRoomInfoDto.content().title());
       assertEquals(expected.participantsInfoDto().participantCount(),
           watchRoomInfoDto.participantsInfoDto().participantCount());
 


### PR DESCRIPTION
## 🛰️ Issue Number
- 프론트엔드에서 content id와 추가 정보 필요로 하여 contentDto를 추가함

## 🪐 작업 내용
- 시청방 정보 DTO에 ContentDto 추가

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?