### PR TITLE
fix: 실시간 시청방 생성시 title 미적용 문제 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -56,6 +56,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
         ContentNotFoundException::new);
 
     WatchRoom watchRoom = WatchRoom.builder()
+        .title(request.title())
         .owner(owner)
         .content(content)
         .build();


### PR DESCRIPTION
## 🛰️ Issue Number

- 실시간 시청방 생성 오류

## 🪐 작업 내용
- WatchRoom 엔티티 생성 시 title 미적용 수정


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?