### PR TITLE
chore: SecurityConfig.java에 prometheus 엔드포인트 허용

### DIFF
--- a/src/main/java/team03/mopl/common/config/SecurityConfig.java
+++ b/src/main/java/team03/mopl/common/config/SecurityConfig.java
@@ -49,6 +49,9 @@ public class SecurityConfig {
             .requestMatchers("/ws/**").permitAll()
             .requestMatchers("/swagger-ui*/**", "/api-docs/**", "/v3/api-docs/**").permitAll()
             .requestMatchers("/actuator/health").permitAll()
+            .requestMatchers("/actuator/prometheus").permitAll()
+            .requestMatchers("/actuator/info", "/actuator/metrics", "/actuator/loggers")
+            .hasRole("ADMIN")
             .requestMatchers("/error").permitAll()
             // SSE 엔드포인트를 permitAll로 설정
             .requestMatchers("/api/notifications/subscribe").permitAll()
@@ -56,7 +59,9 @@ public class SecurityConfig {
         )
         .exceptionHandling(ex -> ex
             .authenticationEntryPoint(((request, response, authException) -> {
-              if (response.isCommitted()) return;
+              if (response.isCommitted()) {
+                return;
+              }
               response.setStatus(401);
               response.setContentType("application/json;charset=utf-8");
               try {
@@ -66,7 +71,9 @@ public class SecurityConfig {
               }
             }))
             .accessDeniedHandler(((request, response, accessDeniedException) -> {
-              if (response.isCommitted()) return;
+              if (response.isCommitted()) {
+                return;
+              }
               response.setStatus(403);
               response.setContentType("application/json;charset=utf-8");
               try {


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
/actuator/prometheus 엔드포인트를 securityConfig에서 permitAll()로 두었습니다.


<img width="558" height="104" alt="image" src="https://github.com/user-attachments/assets/6dc3ebee-bad1-437c-a5c7-8d3fe59831b6" />

**application.yaml이 업데이트 되었습니다. 해당 사안 업데이트 하지 않으면 사용하지 못하니 확인하고 업데이트 해주세요.**

---
**[확인할 수 있는 것]**

<img width="1228" height="1017" alt="image" src="https://github.com/user-attachments/assets/8d50ba00-8c26-4edd-8e3c-0f1ab8c5111b" />

http://localhost:8080/actuator/prometheus 

로컬에서 띄울 시 해당 링크로 위와 같은 정보를 확인할 수 있습니다.
(몇 번 요청을 했고, 평균적으로 얼마나 걸렸는지 등)

--
"/actuator/info", "/actuator/metrics", "/actuator/loggers"

info: 빌드 정보, Git 정보 등 애플리케이션 메타 정보
metrics: JVM, 메모리, CPU 등 성능 메트릭
loggers: 런타임에 로깅 레벨 확인 및 변경 가능

예민할 수 있는 세 가지는 ADMIN 일 때 읽을 수 있도록 해놨습니다!

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?