### PR TITLE
fix: sse 연결 메세지 저장 로직 삭제 및 보안 레벨 수정

### DIFF
--- a/src/main/java/team03/mopl/common/config/SecurityConfig.java
+++ b/src/main/java/team03/mopl/common/config/SecurityConfig.java
@@ -51,7 +51,6 @@ public class SecurityConfig {
             .requestMatchers("/actuator/health").permitAll()
             .requestMatchers("/error").permitAll()
             // SSE 엔드포인트를 permitAll로 설정
-            .requestMatchers("/api/notifications/subscribe").permitAll()
             .anyRequest().hasRole("USER")
         )
         .exceptionHandling(ex -> ex

--- a/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team03/mopl/domain/notification/controller/NotificationController.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,16 +38,16 @@ public class NotificationController {
    * SSE 구독 연결
    * SSE 구독 연결 ResponseEntity나 JSON을 반환하면 SSE 프로토콜이 성립하지 않아서 EventSource나 SSE 클라이언트가 아예 수신을 못 합니다.
    */
-  @GetMapping("/subscribe")
+  @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
   public SseEmitter subscribe(@AuthenticationPrincipal CustomUserDetails user,
       @RequestHeader(value = "Last-Event-ID", required = false) String lastEventId,
       HttpServletResponse response) {
 
     // SSE를 위한 응답 헤더 설정
-    response.setHeader("Cache-Control", "no-cache");
+/*    response.setHeader("Cache-Control", "no-cache");
     response.setHeader("Connection", "keep-alive");
     response.setHeader("Content-Type", "text/event-stream");
-    response.setHeader("Access-Control-Expose-Headers", "Cache-Control, Connection, Content-Type");
+    response.setHeader("Access-Control-Expose-Headers", "Cache-Control, Connection, Content-Type");*/
 
     log.info("=== SSE 구독 요청 시작 ===");
     log.info("User 정보: {}", user);
@@ -91,15 +92,9 @@ public class NotificationController {
 
       log.debug("SSE Emitter 구독 완료");
 
-      // 4. 연결된 사실을 알림으로 저장
-      log.debug("CONNECTED 알림 생성 중...");
-      NotificationDto notificationDto = new NotificationDto(userId, NotificationType.CONNECTED, "SSE 연결 완료");
-      UUID connectedNotificationId = notificationService.sendNotification(notificationDto);
-      log.debug("CONNECTED 알림 생성 완료: notificationId={}", connectedNotificationId);
-
-      // 5. 구독 직후, CONNECTED 알림 전송
+      // 4. 구독 직후, CONNECTED 알림 전송
       log.debug("초기 알림 전송 중...");
-      emitterService.sendInitNotification(emitter, connectedNotificationId, notificationDto);
+      emitterService.sendInitNotification(emitter);
       log.info("SSE 구독 완료: userId={}", userId);
 
       return emitter;

--- a/src/main/java/team03/mopl/domain/notification/service/EmitterService.java
+++ b/src/main/java/team03/mopl/domain/notification/service/EmitterService.java
@@ -43,7 +43,6 @@ public class EmitterService {
 
   public SseEmitter subscribe(UUID userId, String lastNotificationId ) {
 
-
     // 기존 연결 정리 먼저 수행
     cleanupExistingConnections(userId);
 
@@ -397,13 +396,12 @@ public class EmitterService {
     log.info("누락된 알림 재전송 완료: userId = {}, 재전송 수 = {}", userId, resendCount);
   }
 
-  public void sendInitNotification(SseEmitter emitter, UUID notificationId, NotificationDto notificationDto) {
+  public void sendInitNotification(SseEmitter emitter) {
     try {
       emitter.send(SseEmitter.event()
-          .id(notificationId.toString())
           .name(NotificationType.CONNECTED.getNotificationName())
-          .data(notificationDto));
-      log.info("초기 연결 알림 전송 완료: notificationId = {}", notificationId);
+          .data("연결됨"));
+      log.info("초기 연결 알림 전송 완료");
     } catch (Exception e) {
       log.warn("초기 연결 알림 전송 실패: 에러={}", e.getMessage());
     }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
### SecurityConfig 수정 
-  /api/notifications/subscribe 엔드포인트 permitAll() -> hasRole("USER")로 변경

### SSE 연결 메세지 수정
- SSE 연결 시 연결 메세지가 알림 엔티티로 저장되던 문제 수정
- @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)로 미디어 타입 event-stream으로 명시, 그 외 불필요한 헤더 설정 제거



## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?