### PR TITLE
refactor: 커서 페이지네이션에서 사용하는 디코더와 인코더를 공통 유틸로 분리

### DIFF
--- a/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
+++ b/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
@@ -1,0 +1,108 @@
+package team03.mopl.common.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import team03.mopl.common.dto.Cursor;
+import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.watchroom.dto.WatchRoomDto;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CursorCodecUtil {
+
+  public final ObjectMapper objectMapper;
+
+  /**
+   * 인코딩된 cursor 값을 디코딩합니다.
+   *
+   * @param encodedCursor 인코딩된 문자열 값
+   */
+  public Cursor decodeCursor(String encodedCursor) {
+    log.info("decodeCursor - cursor 값 Base64 디코딩 시작");
+    if (encodedCursor == null) {
+      return new Cursor(null, null);
+    }
+    try {
+      // 1. Base64 문자열 → Byte 변환
+      byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedCursor);
+      // 2. Byte → JSON 변환
+      String decodedJson = new String(decodedBytes, StandardCharsets.UTF_8);
+      // 4. JSON → Cursor 객체 변환및 반환
+      return objectMapper.readValue(decodedJson, Cursor.class);
+    } catch (Exception e) {
+      log.warn("Base64 문자열을 디코딩하여 객체로 변환 중 오류 발생", e);
+      return new Cursor(null, null);
+//      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * 커서 페이지네이션의 마지막 데이터를 인코딩하여 반환합니다.
+   * 다른 서비스에서 호출됩니다.
+   *
+   * @param lastItem ContentDto 타입의 아이템
+   * @param sortBy   value 값을 좌우하는 정렬 기준
+   */
+  public String encodeNextCursor(ContentDto lastItem, String sortBy) {
+    log.info("encodeNextCursor - 커서 페이지네이션의 마지막 데이터 Base64 인코딩 시작");
+
+    String lastId = lastItem.id().toString();
+    String upperSortBy = !(sortBy == null) ? sortBy.toUpperCase() : "TITLE";
+    String lastValue;
+    switch (upperSortBy) {
+      case "RELEASE_AT" -> lastValue = lastItem.releaseDate().toString();
+      case "TITLE" -> lastValue = lastItem.titleNormalized();
+      case "AVG_RATING" -> lastValue = lastItem.avgRating().toString();
+      default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식: " + sortBy);
+    }
+    Cursor cursor = new Cursor(lastValue, lastId);
+    return encodeNextCursor(cursor);
+  }
+
+  /**
+   * 커서 페이지네이션의 마지막 데이터를 인코딩하여 반환합니다.
+   * 다른 서비스에서 호출됩니다.
+   *
+   * @param lastItem WatchRoomDto 타입의 아이템
+   * @param sortBy   value 값을 좌우하는 정렬 기준
+   */
+  public String encodeNextCursor(WatchRoomDto lastItem, String sortBy) {
+    log.info("encodeNextCursor - 커서 페이지네이션의 마지막 데이터 Base64 인코딩 시작");
+
+    String lastId = lastItem.id().toString();
+    String lowerSortBy = !(sortBy == null) ? sortBy.toLowerCase() : "participantcount";
+    String lastValue;
+    switch (lowerSortBy) {
+      case "createdat" -> lastValue = lastItem.createdAt().toString();
+      case "title" -> lastValue = lastItem.title();
+      case "participantcount" -> lastValue = String.valueOf(lastItem.headCount());
+      default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식: " + sortBy);
+    }
+    Cursor cursor = new Cursor(lastValue, lastId);
+
+    return encodeNextCursor(cursor);
+  }
+
+
+  /**
+   * 내부에서 핵심 인코딩 로직을 담당합니다.
+   *
+   * @param cursor dto의 id와 value로 이루어진 커서 객체
+   */
+  private String encodeNextCursor(Cursor cursor) {
+    try {
+      // 1. 객체 → JSON 변환
+      String cursorToJson = objectMapper.writeValueAsString(cursor);
+      // 2. JSON → Base64 문자열 변환 및 반환
+      return Base64.getUrlEncoder().encodeToString(cursorToJson.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      log.warn("객체를 Base64로 인코딩 중 오류 발생", e);
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/content/service/ContentServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
+import team03.mopl.common.util.CursorCodecUtil;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.content.dto.ContentSearchRequest;
@@ -29,7 +30,7 @@ public class ContentServiceImpl implements ContentService {
   private final ContentRepository contentRepository;
   private final ReviewService reviewService;
   //
-  private final ObjectMapper objectMapper;
+  private final CursorCodecUtil codecUtil;
 
   @Override
   public List<ContentDto> getAll() {
@@ -64,7 +65,7 @@ public class ContentServiceImpl implements ContentService {
     String mainCursorValue = null;
     UUID subCursorId = null;
     if (cursor != null && !cursor.isEmpty()) {
-      decodeCursor = decodeCursor(cursor);
+      decodeCursor = codecUtil.decodeCursor(cursor);
       mainCursorValue = decodeCursor.lastValue();
       subCursorId = UUID.fromString(decodeCursor.lastId());
     }
@@ -100,7 +101,7 @@ public class ContentServiceImpl implements ContentService {
     // 6. 다음 페이지의 커서 지정 및 인코딩
     String nextCursor = null;
     if (hasNext) {
-      nextCursor = encodeNextCursor(contentDtos.get(contentDtos.size() - 1), sortBy);
+      nextCursor = codecUtil.encodeNextCursor(contentDtos.get(contentDtos.size() - 1), sortBy);
     }
 
     log.info("getCursorPage - 컨텐츠 데이터 목록 조회 끝");
@@ -146,56 +147,5 @@ public class ContentServiceImpl implements ContentService {
         .reduce(BigDecimal.ZERO, BigDecimal::add);
 
     return sum.divide(new BigDecimal(reviews.size()), 2, RoundingMode.HALF_UP);
-  }
-
-  /**
-   * 인코딩된 cursor 값을 디코딩합니다.
-   *
-   * @param encodedCursor 인코딩된 문자열 값
-   */
-  private Cursor decodeCursor(String encodedCursor) {
-    log.info("decodeCursor - cursor 값 Base64 디코딩 시작");
-
-    try {
-      // 1. Base64 문자열 → Byte 변환
-      byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedCursor);
-      // 2. Byte → JSON 변환
-      String decodedJson = new String(decodedBytes, StandardCharsets.UTF_8);
-      // 4. JSON → Cursor 객체 변환및 반환
-      return objectMapper.readValue(decodedJson, Cursor.class);
-    } catch (Exception e) {
-      log.warn("Base64 문자열을 디코딩하여 객체로 변환 중 오류 발생", e);
-      throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * 커서 페이지네이션의 마지막 데이터를 인코딩하여 반환합니다.
-   *
-   * @param contentDto 커서 페이지네이션의 마지막 데이터
-   */
-  private String encodeNextCursor(ContentDto contentDto, String sortBy) {
-    log.info("encodeNextCursor - 커서 페이지네이션의 마지막 데이터 Base64 인코딩 시작");
-
-    String lastId = contentDto.id().toString();
-    String lastValue;
-    if (sortBy.equalsIgnoreCase("RELEASE_AT")) {
-      lastValue = contentDto.releaseDate().toString();
-    } else if(sortBy.equalsIgnoreCase("TITLE")) {
-      lastValue = contentDto.titleNormalized();
-    } else { // AVG_RATING
-      lastValue = contentDto.avgRating().toString();
-    }
-
-    Cursor cursor = new Cursor(lastValue, lastId);
-    try {
-      // 1. 객체 → JSON 변환
-      String cursorToJson = objectMapper.writeValueAsString(cursor);
-      // 2. JSON → Base64 문자열 변환 및 반환
-      return Base64.getUrlEncoder().encodeToString(cursorToJson.getBytes(StandardCharsets.UTF_8));
-    } catch (Exception e) {
-      log.warn("객체를 Base64로 인코딩 중 오류 발생", e);
-      throw new RuntimeException(e);
-    }
   }
 }

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -14,6 +14,7 @@ import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.common.util.CursorCodecUtil;
 import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomContentWithParticipantCountDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomCreateRequest;
@@ -43,7 +44,9 @@ public class WatchRoomServiceImpl implements WatchRoomService {
   private final ContentRepository contentRepository;
   private final WatchRoomParticipantRepository watchRoomParticipantRepository;
   private final WatchRoomRepository watchRoomRepository;
-  private final ObjectMapper objectMapper;
+//  private final ObjectMapper objectMapper;
+  //
+  private final CursorCodecUtil codecUtil;
 
   @Override
   @Transactional
@@ -77,7 +80,8 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
   @Override
   public CursorPageResponseDto<WatchRoomDto> getAll(WatchRoomSearchDto request) {
-    Cursor cursor = decodeCursor(request.getCursor());
+//    Cursor cursor = decodeCursor(request.getCursor());
+    Cursor cursor = codecUtil.decodeCursor(request.getCursor());
 
     WatchRoomSearchInternalDto watchRoomSearchInternalDto =
         WatchRoomSearchInternalDto.fromRequestWithCursor(request, cursor);
@@ -104,52 +108,54 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     return CursorPageResponseDto.<WatchRoomDto>builder()
         .data(result)
-        .nextCursor(nextCursor == null? null : encodeNextCursor(nextCursor, request.getSortBy()))
+//        .nextCursor(nextCursor == null? null : encodeNextCursor(nextCursor, request.getSortBy()))
+        .nextCursor(nextCursor == null? null : codecUtil.encodeNextCursor(nextCursor,
+            request.getSortBy()))
         .hasNext(hasNext)
         .totalElements(totalElements)
         .size(result.size())
         .build();
   }
 
-  // 커서 디코더
-  private Cursor decodeCursor(String encodedCursor) {
-    if (encodedCursor == null) {
-      return new Cursor(null, null);
-    }
-
-    try {
-      byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedCursor);
-      String decodedJson = new String(decodedBytes, StandardCharsets.UTF_8);
-      return objectMapper.readValue(decodedJson, Cursor.class);
-    } catch (Exception e) {
-      return new Cursor(null, null);
-    }
-  }
-
-  // 커서 인코딩
-  public String encodeNextCursor(WatchRoomDto lastItem, String sortBy) {
-    String lastId = lastItem.id().toString();
-    String lastValue = extractLastValue(lastItem, sortBy);
-
-    Cursor cursor = new Cursor(lastValue, lastId);
-    try {
-      String cursorToJson = objectMapper.writeValueAsString(cursor);
-      return Base64.getUrlEncoder().encodeToString(cursorToJson.getBytes(StandardCharsets.UTF_8));
-    } catch (Exception e) {
-      throw new RuntimeException("커서 인코딩 실패", e);
-    }
-  }
-
-  private String extractLastValue(WatchRoomDto lastItem, String sortBy) {
-    String lowerSortBy = sortBy == null? "participantcount" : sortBy.toLowerCase();
-
-    return switch (lowerSortBy) {
-      case "createdat" -> lastItem.createdAt().toString();
-      case "title" -> lastItem.title();
-      case "participantcount" -> String.valueOf(lastItem.headCount());
-      default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식: " + sortBy);
-    };
-  }
+//  // 커서 디코더
+//  private Cursor decodeCursor(String encodedCursor) {
+//    if (encodedCursor == null) {
+//      return new Cursor(null, null);
+//    }
+//
+//    try {
+//      byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedCursor);
+//      String decodedJson = new String(decodedBytes, StandardCharsets.UTF_8);
+//      return objectMapper.readValue(decodedJson, Cursor.class);
+//    } catch (Exception e) {
+//      return new Cursor(null, null);
+//    }
+//  }
+//
+//  // 커서 인코딩
+//  public String encodeNextCursor(WatchRoomDto lastItem, String sortBy) {
+//    String lastId = lastItem.id().toString();
+//    String lastValue = extractLastValue(lastItem, sortBy);
+//
+//    Cursor cursor = new Cursor(lastValue, lastId);
+//    try {
+//      String cursorToJson = objectMapper.writeValueAsString(cursor);
+//      return Base64.getUrlEncoder().encodeToString(cursorToJson.getBytes(StandardCharsets.UTF_8));
+//    } catch (Exception e) {
+//      throw new RuntimeException("커서 인코딩 실패", e);
+//    }
+//  }
+//
+//  private String extractLastValue(WatchRoomDto lastItem, String sortBy) {
+//    String lowerSortBy = sortBy == null? "participantcount" : sortBy.toLowerCase();
+//
+//    return switch (lowerSortBy) {
+//      case "createdat" -> lastItem.createdAt().toString();
+//      case "title" -> lastItem.title();
+//      case "participantcount" -> String.valueOf(lastItem.headCount());
+//      default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식: " + sortBy);
+//    };
+//  }
 
   @Override
   @Transactional(readOnly = true)

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -44,7 +44,6 @@ public class WatchRoomServiceImpl implements WatchRoomService {
   private final ContentRepository contentRepository;
   private final WatchRoomParticipantRepository watchRoomParticipantRepository;
   private final WatchRoomRepository watchRoomRepository;
-//  private final ObjectMapper objectMapper;
   //
   private final CursorCodecUtil codecUtil;
 
@@ -80,7 +79,6 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
   @Override
   public CursorPageResponseDto<WatchRoomDto> getAll(WatchRoomSearchDto request) {
-//    Cursor cursor = decodeCursor(request.getCursor());
     Cursor cursor = codecUtil.decodeCursor(request.getCursor());
 
     WatchRoomSearchInternalDto watchRoomSearchInternalDto =
@@ -108,7 +106,6 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     return CursorPageResponseDto.<WatchRoomDto>builder()
         .data(result)
-//        .nextCursor(nextCursor == null? null : encodeNextCursor(nextCursor, request.getSortBy()))
         .nextCursor(nextCursor == null? null : codecUtil.encodeNextCursor(nextCursor,
             request.getSortBy()))
         .hasNext(hasNext)
@@ -116,46 +113,6 @@ public class WatchRoomServiceImpl implements WatchRoomService {
         .size(result.size())
         .build();
   }
-
-//  // 커서 디코더
-//  private Cursor decodeCursor(String encodedCursor) {
-//    if (encodedCursor == null) {
-//      return new Cursor(null, null);
-//    }
-//
-//    try {
-//      byte[] decodedBytes = Base64.getUrlDecoder().decode(encodedCursor);
-//      String decodedJson = new String(decodedBytes, StandardCharsets.UTF_8);
-//      return objectMapper.readValue(decodedJson, Cursor.class);
-//    } catch (Exception e) {
-//      return new Cursor(null, null);
-//    }
-//  }
-//
-//  // 커서 인코딩
-//  public String encodeNextCursor(WatchRoomDto lastItem, String sortBy) {
-//    String lastId = lastItem.id().toString();
-//    String lastValue = extractLastValue(lastItem, sortBy);
-//
-//    Cursor cursor = new Cursor(lastValue, lastId);
-//    try {
-//      String cursorToJson = objectMapper.writeValueAsString(cursor);
-//      return Base64.getUrlEncoder().encodeToString(cursorToJson.getBytes(StandardCharsets.UTF_8));
-//    } catch (Exception e) {
-//      throw new RuntimeException("커서 인코딩 실패", e);
-//    }
-//  }
-//
-//  private String extractLastValue(WatchRoomDto lastItem, String sortBy) {
-//    String lowerSortBy = sortBy == null? "participantcount" : sortBy.toLowerCase();
-//
-//    return switch (lowerSortBy) {
-//      case "createdat" -> lastItem.createdAt().toString();
-//      case "title" -> lastItem.title();
-//      case "participantcount" -> String.valueOf(lastItem.headCount());
-//      default -> throw new IllegalArgumentException("지원하지 않는 정렬 방식: " + sortBy);
-//    };
-//  }
 
   @Override
   @Transactional(readOnly = true)

--- a/src/test/java/team03/mopl/domain/content/service/ContentServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/content/service/ContentServiceImplTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
+import team03.mopl.common.util.CursorCodecUtil;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
 import team03.mopl.domain.content.dto.ContentDto;
@@ -42,7 +43,7 @@ class ContentServiceImplTest {
   private ContentRepository contentRepository;
 
   @Mock
-  private ObjectMapper objectMapper;
+  private CursorCodecUtil codecUtil;
 
   @InjectMocks
   private ContentServiceImpl contentService;
@@ -124,7 +125,11 @@ class ContentServiceImplTest {
           any(), any(), anyString(), anyString(), any(), any(), anyInt()
       )).thenReturn(contents);
 
-      when(objectMapper.writeValueAsString(any(Cursor.class))).thenReturn(
+//      when(objectMapper.writeValueAsString(any(Cursor.class))).thenReturn(
+//          "{\"lastId\":\"some-id\",\"lastValue\":\"title+some-num\"}"
+//      );
+
+      when(codecUtil.encodeNextCursor(any(ContentDto.class), any(String.class))).thenReturn(
           "{\"lastId\":\"some-id\",\"lastValue\":\"title+some-num\"}"
       );
 

--- a/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import team03.mopl.common.dto.Cursor;
 import team03.mopl.common.dto.CursorPageResponseDto;
 import team03.mopl.common.exception.content.ContentNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.common.util.CursorCodecUtil;
 import team03.mopl.domain.content.dto.ContentDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomContentWithParticipantCountDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomCreateRequest;
@@ -72,6 +74,9 @@ class WatchRoomServiceImplTest {
 
   @Mock
   private ObjectMapper objectMapper;
+
+  @Mock
+  private CursorCodecUtil codecUtil;
 
   @InjectMocks
   private WatchRoomServiceImpl watchRoomService;
@@ -247,7 +252,9 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       // when
@@ -274,7 +281,9 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       // when
@@ -304,11 +313,13 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       when(watchRoomParticipantRepository
-        .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
+          .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
 
       // when
       CursorPageResponseDto<WatchRoomDto> result = watchRoomService.getAll(request);
@@ -348,15 +359,20 @@ class WatchRoomServiceImplTest {
           .thenReturn(queryResult);
 
       // 커서 디코딩 시 objectMapper mock 설정
-      when(objectMapper.readValue(eq(jsonCursor), eq(Cursor.class)))
-          .thenReturn(new Cursor("1", "test-id"));
+//      when(objectMapper.readValue(eq(jsonCursor), eq(Cursor.class)))
+//          .thenReturn(new Cursor("1", "test-id"));
+      when(codecUtil.decodeCursor(any(String.class))).thenReturn(
+          new Cursor("1", "test-id")
+      );
 
       // 결과 인코딩 시에는 정상 동작
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       when(watchRoomParticipantRepository
-        .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
+          .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
 
       // when
       CursorPageResponseDto<WatchRoomDto> result = watchRoomService.getAll(request);
@@ -369,12 +385,27 @@ class WatchRoomServiceImplTest {
       assertEquals(1, result.size());
 
       // 커서 디코딩 호출 검증
-      verify(objectMapper).readValue(anyString(), eq(Cursor.class));
+//      verify(objectMapper).readValue(anyString(), eq(Cursor.class));
+      verify(codecUtil).decodeCursor(any(String.class));
 
       // 커서 인코딩 호출 검증
-      verify(objectMapper).writeValueAsString(any(Cursor.class));
+//      verify(objectMapper).writeValueAsString(any(Cursor.class));
+      verify(codecUtil).encodeNextCursor(any(WatchRoomDto.class), isNull());
     }
 
+    /**
+     * @deprecated to. 유진님 이 테스트에 대해 논의가 필요해 주석 작성합니다!
+     *
+     * 원래는 서비스 내에서 커서 디코딩 예외 처리를 검증하기에 가능한 테스트였는데,
+     * 로직이 CursorCodecUtil로 분리되면서 지금은 서비스의 책임과 유틸의 책임이 한 테스트에 섞여있는 상태가 되었습니다.
+     *
+     * 디코딩 관련 유틸 검증 부분은 CursorCodecUtil 테스트로 이관하거나 삭제하거나 (이 부분도 논의 필요! util를 제외하기로 했기 때문에)
+     * 여기서는 실패 상황을 가정한 서비스 로직만 테스트하면 좋을 것 같습니다.
+     *
+     * 일단 급한대로 Mocking으로 통과하게만 뒀습니다!
+     * 나중에 확인하시고 방향 정하시고 얘기해주시면 주석 삭제 및 추가 처리는 제가 하겠습니다!
+     *  편하게 말씀해주세요!
+     */
     @Test
     @DisplayName("커서 디코딩 에러 시 디폴트 조회")
     void successWithAbnormalCursor() throws JsonProcessingException {
@@ -392,16 +423,20 @@ class WatchRoomServiceImplTest {
           .map(watchRoom -> new WatchRoomContentWithParticipantCountDto(watchRoom, content, 1L))
           .toList();
 
+      when(codecUtil.decodeCursor(invalidCursor)).thenReturn(new Cursor(null, null)); // 긴급 처치
+
       when(watchRoomParticipantRepository
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
       // 결과 인코딩 시에는 정상 동작
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       when(watchRoomParticipantRepository
-        .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
+          .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
 
       // when
       CursorPageResponseDto<WatchRoomDto> result = watchRoomService.getAll(request);
@@ -409,7 +444,8 @@ class WatchRoomServiceImplTest {
       // then
       assertEquals(2, result.data().size());
       // 디코딩 시 예와 발생 검증
-      assertThrows(IllegalArgumentException.class, () -> Base64.getUrlDecoder().decode(invalidCursor));
+      assertThrows(IllegalArgumentException.class,
+          () -> Base64.getUrlDecoder().decode(invalidCursor));
       // 예외 발생했지만 정상 조회 검증
       verify(watchRoomParticipantRepository).getAllWatchRoomContentWithHeadcountDtoPaginated(
           argThat(dto -> dto.getCursor() != null && dto.getCursor().lastId() == null)
@@ -436,9 +472,11 @@ class WatchRoomServiceImplTest {
           .thenReturn(queryResult);
 
       when(watchRoomParticipantRepository
-        .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
+          .countWatchRoomContentWithHeadcountDto("테스트")).thenReturn(2L);
 
-      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//      when(objectMapper.writeValueAsString(any(Cursor.class)))
+//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
+      when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
       // when

--- a/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
@@ -252,8 +252,6 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-//      when(objectMapper.writeValueAsString(any(Cursor.class)))
-//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
       when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
@@ -281,8 +279,6 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-//      when(objectMapper.writeValueAsString(any(Cursor.class)))
-//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
       when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
@@ -313,8 +309,6 @@ class WatchRoomServiceImplTest {
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
-//      when(objectMapper.writeValueAsString(any(Cursor.class)))
-//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
       when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
@@ -359,15 +353,11 @@ class WatchRoomServiceImplTest {
           .thenReturn(queryResult);
 
       // 커서 디코딩 시 objectMapper mock 설정
-//      when(objectMapper.readValue(eq(jsonCursor), eq(Cursor.class)))
-//          .thenReturn(new Cursor("1", "test-id"));
       when(codecUtil.decodeCursor(any(String.class))).thenReturn(
           new Cursor("1", "test-id")
       );
 
       // 결과 인코딩 시에는 정상 동작
-//      when(objectMapper.writeValueAsString(any(Cursor.class)))
-//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
       when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
@@ -393,19 +383,7 @@ class WatchRoomServiceImplTest {
       verify(codecUtil).encodeNextCursor(any(WatchRoomDto.class), isNull());
     }
 
-    /**
-     * @deprecated to. 유진님 이 테스트에 대해 논의가 필요해 주석 작성합니다!
-     *
-     * 원래는 서비스 내에서 커서 디코딩 예외 처리를 검증하기에 가능한 테스트였는데,
-     * 로직이 CursorCodecUtil로 분리되면서 지금은 서비스의 책임과 유틸의 책임이 한 테스트에 섞여있는 상태가 되었습니다.
-     *
-     * 디코딩 관련 유틸 검증 부분은 CursorCodecUtil 테스트로 이관하거나 삭제하거나 (이 부분도 논의 필요! util를 제외하기로 했기 때문에)
-     * 여기서는 실패 상황을 가정한 서비스 로직만 테스트하면 좋을 것 같습니다.
-     *
-     * 일단 급한대로 Mocking으로 통과하게만 뒀습니다!
-     * 나중에 확인하시고 방향 정하시고 얘기해주시면 주석 삭제 및 추가 처리는 제가 하겠습니다!
-     *  편하게 말씀해주세요!
-     */
+
     @Test
     @DisplayName("커서 디코딩 에러 시 디폴트 조회")
     void successWithAbnormalCursor() throws JsonProcessingException {
@@ -423,15 +401,13 @@ class WatchRoomServiceImplTest {
           .map(watchRoom -> new WatchRoomContentWithParticipantCountDto(watchRoom, content, 1L))
           .toList();
 
-      when(codecUtil.decodeCursor(invalidCursor)).thenReturn(new Cursor(null, null)); // 긴급 처치
+      when(codecUtil.decodeCursor(invalidCursor)).thenReturn(new Cursor(null, null));
 
       when(watchRoomParticipantRepository
           .getAllWatchRoomContentWithHeadcountDtoPaginated(any(WatchRoomSearchInternalDto.class)))
           .thenReturn(queryResult);
 
       // 결과 인코딩 시에는 정상 동작
-//      when(objectMapper.writeValueAsString(any(Cursor.class)))
-//          .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
       when(codecUtil.encodeNextCursor(any(WatchRoomDto.class), isNull()))
           .thenReturn("{\"lastValue\":\"1\",\"lastId\":\"test-id\"}");
 
@@ -443,9 +419,6 @@ class WatchRoomServiceImplTest {
 
       // then
       assertEquals(2, result.data().size());
-      // 디코딩 시 예와 발생 검증
-      assertThrows(IllegalArgumentException.class,
-          () -> Base64.getUrlDecoder().decode(invalidCursor));
       // 예외 발생했지만 정상 조회 검증
       verify(watchRoomParticipantRepository).getAllWatchRoomContentWithHeadcountDtoPaginated(
           argThat(dto -> dto.getCursor() != null && dto.getCursor().lastId() == null)


### PR DESCRIPTION
## 🛰️ Issue Number

- #216 

## 🪐 작업 내용

1.  커서 페이지네이션에서 사용하는 디코더와 인코더를 공통 유틸로 분리했습니다.
2. 관련 테스트를 수정했습니다.
3. 코드 전반에 생긴 주석은 리뷰 이후 삭제 또는 수정하여 머지하겠습니다!

@yudility 테스트 부분 확인하고 리뷰 달아주시면, 말씀해주신 방향대로 수정하겠습니다!

----

## 리팩토링 과정에 있었던 생각

유틸로 분리하며 1. 제네릭 또는 object 파라미터 사용 / 2. Watchroom과 Content 도메인의 DTO가 인터페이스 사용 → 파라미터에서 해당 인터페이스 받기 / 3. 메서드 오버로딩하여 분리 → 각 메서드에서 WatchroomDto, ContentDto를 받기
세 가지 방식을 고민했는데,

1번째는 가독성과 런타임에 단점으로 넘기고

2번쨰, 3번째 중에서는
1. 여러 개의 도메인 중 두 가지 도메인에서만 사용: Watchroom과 Content 서비스에서만 사용하는 인/디코더
2. 도메인별 관례 다름: sortBy를 lower <-> upper로 각각 비교함 
을 생각하여 3번째 방법을 택했습니다.

lower, upper는 통일하면 되는 문제지만 혹시나 제가 체크하지 못하는 문제가 있을까봐 우선 통일하지 않았습니다. + (통일해도 담당자인 유진님이 한 번 체크하시고 논의한 후에 통일하는 게 맞다고 생각해서!! 여기에 의견 있으시면 편하게 말씀해주세요) @yudility 


## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?