### PR TITLE
chore: schema.sql 의 contents 테이블의 옵션 수정

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE "contents"
     "id"               UUID PRIMARY KEY                  NOT NULL,
     "title"            VARCHAR(255)                      NOT NULL,
     "title_normalized" VARCHAR(255) COLLATE "ko_KR.utf8" NOT NULL,
-    "data_id"          varchar(255)                      NULL,
+    "data_id"          VARCHAR(255)                      NULL,
     "description"      TEXT                              NULL,
     "content_type"     VARCHAR(50)                       NOT NULL,
     "release_date"     TIMESTAMP                         NOT NULL,

--- a/init/schema.sql
+++ b/init/schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE "contents"
 (
     "id"               UUID PRIMARY KEY                  NOT NULL,
     "title"            VARCHAR(255)                      NOT NULL,
-    "title_normalized" VARCHAR(255)                      NOT NULL,
+    "title_normalized" VARCHAR(255) COLLATE "ko_KR.utf8" NOT NULL,
     "data_id"          varchar(255)                      NULL,
     "description"      TEXT                              NULL,
     "content_type"     VARCHAR(50)                       NOT NULL,


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용

- title_normalized 컬럼에 누락된 COLLATE "ko_KR.utf8" 옵션 추가
- data_id의 VARCHAR 대소문자 통일

COLLATE "ko_KR.utf8" 의 경우 데이터베이스에 ko_KR.utf8 로케일(한국어-대한민국의 UTF-8 인코딩 사용)이 설치되어 있지 않을 경우, 존재하지 않는다는 에러가 뜹니다. 때문에 로컬에서 사용할 땐 번거로우시더라도 제거한 후 사용하시거나 따로 로케일 설치하여 하시는 걸 추천드립니다!

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?