### PR TITLE
feat: 각 도메인의 서비스 로직에 알림 기능 구현

### DIFF
--- a/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
+++ b/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import team03.mopl.common.dto.Cursor;
 import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.notification.dto.NotificationDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomDto;
 
 @Slf4j
@@ -85,6 +86,20 @@ public class CursorCodecUtil {
     }
     Cursor cursor = new Cursor(lastValue, lastId);
 
+    return encodeNextCursor(cursor);
+  }
+
+  /**
+   * 커서 페이지네이션의 마지막 데이터를 인코딩하여 반환합니다.
+   * 다른 서비스에서 호출됩니다.
+   *
+   * @param lastItem NotificationDto 타입의 아이템
+   */
+  public String encodeNextCursor(NotificationDto lastItem) {
+    Cursor cursor = new Cursor(
+        lastItem.getCreatedAt().toString(),
+        lastItem.getId().toString()
+    );
     return encodeNextCursor(cursor);
   }
 

--- a/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
+++ b/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
@@ -39,7 +39,7 @@ public class NotificationEventListener {
     UUID playlistId = event.playlistId();
     List<Subscription> subs = subscriptionRepository.findByPlaylistId(playlistId);
     if (subs.isEmpty()) {
-      log.info("구독자가 없어 알림 전송 없음: playlistId={}", playlistId);
+      log.debug("구독자가 없어 알림 전송 없음: playlistId={}", playlistId);
       return;
     }
 

--- a/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
+++ b/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
@@ -61,7 +61,7 @@ public class NotificationEventListener {
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void onPlaylistSubscribed(PlaylistSubscribedEvent event) {
     // 알림 내용은 필요에 따라 가공
-    String content = "당신의 플레이리스트가 새로운 구독자를 얻었습니다.";
+    String content = "당신의 "+event.title()+" 플레이리스트에 새로운 구독자가 등록되었습니다.";
     notificationService.sendNotification(
         new NotificationDto(event.ownerId(), NotificationType.PLAYLIST_SUBSCRIBED, content)
     );

--- a/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
+++ b/src/main/java/team03/mopl/domain/notification/NotificationEventListener.java
@@ -1,0 +1,106 @@
+package team03.mopl.domain.notification;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team03.mopl.domain.follow.dto.FollowResponse;
+import team03.mopl.domain.follow.service.FollowService;
+import team03.mopl.domain.notification.dto.NotificationDto;
+import team03.mopl.domain.notification.entity.Notification;
+import team03.mopl.domain.notification.entity.NotificationType;
+import team03.mopl.domain.notification.events.FollowingPostedPlaylistEvent;
+import team03.mopl.domain.notification.events.PlaylistSubscribedEvent;
+import team03.mopl.domain.notification.events.PlaylistUpdatedEvent;
+import team03.mopl.domain.notification.repository.NotificationRepository;
+import team03.mopl.domain.notification.service.NotificationService;
+import team03.mopl.domain.subscription.Subscription;
+import team03.mopl.domain.subscription.SubscriptionRepository;
+import team03.mopl.domain.notification.service.EmitterService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationEventListener {
+
+  private final SubscriptionRepository subscriptionRepository;
+  private final NotificationRepository notificationRepository;
+  private final EmitterService emitterService;
+  private final NotificationService notificationService;
+  private final FollowService followService;
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void handlePlaylistUpdated(PlaylistUpdatedEvent event) {
+    UUID playlistId = event.playlistId();
+    List<Subscription> subs = subscriptionRepository.findByPlaylistId(playlistId);
+    if (subs.isEmpty()) {
+      log.info("구독자가 없어 알림 전송 없음: playlistId={}", playlistId);
+      return;
+    }
+
+    String content = "플레이리스트가 업데이트되었습니다: " + event.playlistTitle();
+    List<Notification> notifications = subs.stream()
+        .map(s -> new Notification(s.getUser().getId(), NotificationType.PLAYLIST_UPDATED, content))
+        .toList();
+
+    notificationRepository.saveAll(notifications);
+
+    // SSE push
+    notifications.forEach(n -> emitterService.sendNotificationToMember(n.getReceiverId(), n));
+
+    log.info("PlaylistUpdatedEvent 처리 완료: playlistId={}, 알림 수={}", playlistId, notifications.size());
+  }
+
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onPlaylistSubscribed(PlaylistSubscribedEvent event) {
+    // 알림 내용은 필요에 따라 가공
+    String content = "당신의 플레이리스트가 새로운 구독자를 얻었습니다.";
+    notificationService.sendNotification(
+        new NotificationDto(event.ownerId(), NotificationType.PLAYLIST_SUBSCRIBED, content)
+    );
+    log.info("PlaylistSubscribedEvent 처리 완료: playlistId={}, ownerId={}, subscriberId={}",
+        event.playlistId(), event.ownerId(), event.subscriberId());
+  }
+
+  @Async
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onFollowingPostedPlaylist(FollowingPostedPlaylistEvent event) {
+    UUID creatorId = event.creatorId();
+    UUID playlistId = event.playlistId();
+    String playlistName = event.playlistName();
+
+    //새로 등록된 플리 -> 나를 팔로우한 사용자에게 알림 전송
+    if (!event.isPublic()) {
+      log.debug("비공개 플레이리스트 생성: 알림 전송 생략 playlistId={}", playlistId);
+      return;
+    }
+
+    //나를 팔로우하고 있는 사람들의 목록
+    List<FollowResponse> followings = followService.getFollowing(creatorId);
+
+    //목록이 없다면 반환
+    if (followings.isEmpty()) {
+      log.debug("구독자가 없어 알림 전송 없음: creatorId={}", event.creatorId());
+      return;
+    }
+
+    String content = "팔로우 중인 사용자(" + event.creatorId() + ")가 새로운 플레이리스트를 만들었습니다: " + playlistName;
+    for (FollowResponse f : followings) {
+      UUID followingId = f.id();
+      notificationService.sendNotification(
+          new NotificationDto(followingId, NotificationType.FOLLOWING_POSTED_PLAYLIST, content)
+      );
+    }
+
+    log.info("onFollowingPostedPlaylist 처리 완료: creatorId={}, playlistId={}, followerCount={}",
+        event.creatorId(), event.playlistId(), followings.size());
+
+  }
+}

--- a/src/main/java/team03/mopl/domain/notification/entity/NotificationType.java
+++ b/src/main/java/team03/mopl/domain/notification/entity/NotificationType.java
@@ -11,7 +11,8 @@ public enum NotificationType {
   UNFOLLOWED("unfollowed"),
   DM_RECEIVED("dm_received"),
   NEW_DM_ROOM("created new DM room"),
-  CONNECTED("connected");
+  CONNECTED("connected"),
+  PLAYLIST_UPDATED("playlist_updated");
 
   private final String notificationName;
 

--- a/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
@@ -1,0 +1,10 @@
+package team03.mopl.domain.notification.events;
+
+import java.util.UUID;
+
+public record FollowingPostedPlaylistEvent(
+  UUID creatorId,
+  UUID playlistId,
+  String playlistName,
+  boolean isPublic
+) {}

--- a/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
@@ -8,3 +8,4 @@ public record FollowingPostedPlaylistEvent(
   String playlistName,
   boolean isPublic
 ) {}
+

--- a/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/FollowingPostedPlaylistEvent.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public record FollowingPostedPlaylistEvent(
   UUID creatorId,
+  String creatorName,
   UUID playlistId,
   String playlistName,
   boolean isPublic

--- a/src/main/java/team03/mopl/domain/notification/events/PlaylistSubscribedEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/PlaylistSubscribedEvent.java
@@ -1,0 +1,10 @@
+package team03.mopl.domain.notification.events;
+
+import java.util.UUID;
+
+public record PlaylistSubscribedEvent(
+    UUID playlistId,
+    UUID ownerId,        // 플레이리스트 주인
+    UUID subscriberId    // 구독한 사용자
+) {}
+

--- a/src/main/java/team03/mopl/domain/notification/events/PlaylistSubscribedEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/PlaylistSubscribedEvent.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public record PlaylistSubscribedEvent(
     UUID playlistId,
     UUID ownerId,        // 플레이리스트 주인
+    String title,
     UUID subscriberId    // 구독한 사용자
 ) {}
 

--- a/src/main/java/team03/mopl/domain/notification/events/PlaylistUpdatedEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/PlaylistUpdatedEvent.java
@@ -1,12 +1,9 @@
 package team03.mopl.domain.notification.events;
 
-import java.util.List;
 import java.util.UUID;
 
 public record PlaylistUpdatedEvent(
     UUID playlistId,
     UUID ownerId,
-    UUID updaterId,
-    List<UUID> addedContentIds,
     String playlistTitle
 ) {}

--- a/src/main/java/team03/mopl/domain/notification/events/PlaylistUpdatedEvent.java
+++ b/src/main/java/team03/mopl/domain/notification/events/PlaylistUpdatedEvent.java
@@ -1,0 +1,12 @@
+package team03.mopl.domain.notification.events;
+
+import java.util.List;
+import java.util.UUID;
+
+public record PlaylistUpdatedEvent(
+    UUID playlistId,
+    UUID ownerId,
+    UUID updaterId,
+    List<UUID> addedContentIds,
+    String playlistTitle
+) {}

--- a/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team03/mopl/domain/notification/repository/NotificationRepository.java
@@ -10,4 +10,6 @@ public interface NotificationRepository extends JpaRepository<Notification, UUID
   List<Notification> findByReceiverIdAndIsRead(UUID receiverId, boolean read);
 
   void deleteByReceiverIdAndIsRead(UUID receiverId, boolean read);
+
+  long countByReceiverId(UUID receiverId);
 }

--- a/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
@@ -192,8 +192,6 @@ public class PlaylistServiceImpl implements PlaylistService {
     eventPublisher.publishEvent(new PlaylistUpdatedEvent(
         playlist.getId(),
         playlist.getUser().getId(),
-        userId,
-        newContents.stream().map(Content::getId).toList(),
         playlist.getName()
     ));
   }

--- a/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.mopl.common.exception.playlist.PlaylistContentAlreadyExistsException;
@@ -18,6 +19,8 @@ import team03.mopl.common.exception.user.UserNotFoundException;
 import team03.mopl.common.util.NormalizerUtil;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.repository.ContentRepository;
+import team03.mopl.domain.notification.events.FollowingPostedPlaylistEvent;
+import team03.mopl.domain.notification.events.PlaylistUpdatedEvent;
 import team03.mopl.domain.playlist.dto.PlaylistCreateRequest;
 import team03.mopl.domain.playlist.dto.PlaylistDto;
 import team03.mopl.domain.playlist.dto.PlaylistUpdateRequest;
@@ -36,6 +39,7 @@ public class PlaylistServiceImpl implements PlaylistService {
   private final PlaylistRepository playlistRepository;
   private final UserRepository userRepository;
   private final ContentRepository contentRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   @Transactional
@@ -51,6 +55,15 @@ public class PlaylistServiceImpl implements PlaylistService {
 
     Playlist savedPlaylist = playlistRepository.save(playlist);
     log.info("create - 플레이리스트 저장: 플레이리스트 생성자 ID = {}, 플레이리트스 ID = {}", userId, playlist.getId());
+
+    //해당 유저를 구독하고 있던 유저들에게 알림 전송
+    eventPublisher.publishEvent(new FollowingPostedPlaylistEvent(
+        userId,
+        savedPlaylist.getId(),
+        savedPlaylist.getName(),
+        savedPlaylist.isPublic()
+    ));
+
     return PlaylistDto.from(savedPlaylist);
   }
 
@@ -174,6 +187,15 @@ public class PlaylistServiceImpl implements PlaylistService {
 
     // 8. Playlist 저장 (cascade로 PlaylistContent도 자동 저장)
     playlistRepository.save(playlist);
+
+    // 9. Playlist를 구독하고 있던 유저에게 알림 전송
+    eventPublisher.publishEvent(new PlaylistUpdatedEvent(
+        playlist.getId(),
+        playlist.getUser().getId(),
+        userId,
+        newContents.stream().map(Content::getId).toList(),
+        playlist.getName()
+    ));
   }
 
   @Override

--- a/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/playlist/service/PlaylistServiceImpl.java
@@ -59,6 +59,7 @@ public class PlaylistServiceImpl implements PlaylistService {
     //해당 유저를 구독하고 있던 유저들에게 알림 전송
     eventPublisher.publishEvent(new FollowingPostedPlaylistEvent(
         userId,
+        user.getName(),
         savedPlaylist.getId(),
         savedPlaylist.getName(),
         savedPlaylist.isPublic()

--- a/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
@@ -56,9 +56,11 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         .build();
     Subscription savedSubscription = subscriptionRepository.save(subscription);
 
+    // 플레이리스트가 구독되면 플레이리스트 소유자에게 알림
     eventPublisher.publishEvent(new PlaylistSubscribedEvent(
         playlist.getId(),
         playlist.getUser().getId(),
+        playlist.getName(),
         user.getId()
     ));
 

--- a/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/subscription/service/SubscriptionServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team03.mopl.common.exception.playlist.PlaylistNotFoundException;
@@ -12,6 +13,7 @@ import team03.mopl.common.exception.subscription.SelfSubscriptionNotAllowedExcep
 import team03.mopl.common.exception.subscription.SubscriptionDeleteDeniedException;
 import team03.mopl.common.exception.subscription.SubscriptionNotFoundException;
 import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.notification.events.PlaylistSubscribedEvent;
 import team03.mopl.domain.playlist.entity.Playlist;
 import team03.mopl.domain.playlist.repository.PlaylistRepository;
 import team03.mopl.domain.subscription.Subscription;
@@ -28,6 +30,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
   private final SubscriptionRepository subscriptionRepository;
   private final UserRepository userRepository;
   private final PlaylistRepository playlistRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   @Transactional
@@ -52,6 +55,12 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         .playlist(playlist)
         .build();
     Subscription savedSubscription = subscriptionRepository.save(subscription);
+
+    eventPublisher.publishEvent(new PlaylistSubscribedEvent(
+        playlist.getId(),
+        playlist.getUser().getId(),
+        user.getId()
+    ));
 
     return SubscriptionDto.from(savedSubscription);
   }

--- a/src/test/java/team03/mopl/domain/dm/repository/DmRepositoryCustomTest.java
+++ b/src/test/java/team03/mopl/domain/dm/repository/DmRepositoryCustomTest.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.util.ReflectionTestUtils;
+import team03.mopl.common.config.QueryDslConfig;
 import team03.mopl.domain.dm.entity.Dm;
 import team03.mopl.domain.dm.entity.DmRoom;
 
@@ -22,7 +23,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@Import({DmRepositoryCustom.class, DmRepositoryCustomTest.QueryDslTestConfig.class})
+@Import({DmRepositoryCustom.class, QueryDslConfig.class})
 @TestPropertySource(properties = {
     "spring.sql.init.mode=never", // schema.sql 자동 실행 막음
     "spring.jpa.hibernate.ddl-auto=create-drop" // 내장 DB에 테이블을 자동으로 생성/삭제
@@ -109,14 +110,5 @@ public class DmRepositoryCustomTest {
     });
   }
 
-
-
-  @TestConfiguration
-  static class QueryDslTestConfig {
-    @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
-      return new JPAQueryFactory(em);
-    }
-  }
 }
 

--- a/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
@@ -1,0 +1,175 @@
+package team03.mopl.domain.notification;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team03.mopl.domain.follow.dto.FollowResponse;
+import team03.mopl.domain.follow.service.FollowService;
+import team03.mopl.domain.notification.dto.NotificationDto;
+import team03.mopl.domain.notification.entity.Notification;
+import team03.mopl.domain.notification.entity.NotificationType;
+import team03.mopl.domain.notification.events.FollowingPostedPlaylistEvent;
+import team03.mopl.domain.notification.events.PlaylistSubscribedEvent;
+import team03.mopl.domain.notification.events.PlaylistUpdatedEvent;
+import team03.mopl.domain.notification.repository.NotificationRepository;
+import team03.mopl.domain.notification.service.EmitterService;
+import team03.mopl.domain.notification.service.NotificationService;
+import team03.mopl.domain.subscription.Subscription;
+import team03.mopl.domain.subscription.SubscriptionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+  @Mock SubscriptionRepository subscriptionRepository;
+  @Mock NotificationRepository notificationRepository;
+  @Mock EmitterService emitterService;
+  @Mock NotificationService notificationService;
+  @Mock FollowService followService;
+
+  @InjectMocks NotificationEventListener listener;
+
+  @DisplayName("플레이리스트 업데이트 시 구독자에게 알림 전송")
+  @Test
+  void handlePlaylistUpdated_withSubscribers() {
+    // given
+    UUID playlistId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
+    String title = "테스트 플레이리스트";
+
+    UUID subUserId = UUID.randomUUID();
+    Subscription sub = mock(Subscription.class, RETURNS_DEEP_STUBS);
+    when(sub.getUser().getId()).thenReturn(subUserId);
+
+    when(subscriptionRepository.findByPlaylistId(playlistId))
+        .thenReturn(List.of(sub));
+    when(notificationRepository.saveAll(anyList()))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    PlaylistUpdatedEvent event = new PlaylistUpdatedEvent(playlistId, ownerId, title);
+
+    // when
+    listener.handlePlaylistUpdated(event);
+
+    // then
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Notification>> captor = ArgumentCaptor.forClass(List.class);
+    verify(notificationRepository).saveAll(captor.capture());
+    List<Notification> saved = captor.getValue();
+
+    assertThat(saved).hasSize(1);
+    Notification n = saved.get(0);
+    assertThat(n.getReceiverId()).isEqualTo(subUserId);
+    assertThat(n.getType()).isEqualTo(NotificationType.PLAYLIST_UPDATED); // 필드명 확인!
+    assertThat(n.getContent()).contains(title);
+
+    verify(emitterService).sendNotificationToMember(eq(subUserId), any(Notification.class));
+  }
+
+  @DisplayName("플레이리스트가 구독되면 플레이리스트 소유자에게 알림을 보낸다")
+  @Test
+  void onPlaylistSubscribed_sendNotificationToOwner() {
+    // given
+    UUID playlistId   = UUID.randomUUID();
+    UUID ownerId      = UUID.randomUUID();
+    UUID subscriberId = UUID.randomUUID();
+
+    PlaylistSubscribedEvent event =
+        new PlaylistSubscribedEvent(playlistId, ownerId, subscriberId);
+
+    // when
+    listener.onPlaylistSubscribed(event);
+
+    // then
+    ArgumentCaptor<NotificationDto> captor = ArgumentCaptor.forClass(NotificationDto.class);
+    verify(notificationService, times(1)).sendNotification(captor.capture());
+
+    NotificationDto dto = captor.getValue();
+    assertThat(dto.getReceiverId()).isEqualTo(ownerId);
+    assertThat(dto.getNotificationType()).isEqualTo(NotificationType.PLAYLIST_SUBSCRIBED);
+    assertThat(dto.getContent()).contains("당신의 플레이리스트가 새로운 구독자를 얻었습니다."); // 메시지 검증
+
+    // 다른 상호작용 없는지
+    verifyNoMoreInteractions(notificationService);
+  }
+
+  @DisplayName("공개 플리 생성 시 팔로워 전원에게 알림 전송")
+  @Test
+  void onFollowingPostedPlaylist_public_playlist_sends_notifications() {
+    // given
+    UUID creatorId = UUID.randomUUID();
+    UUID playlistId = UUID.randomUUID();
+    String playlistName = "새 플리!";
+    FollowingPostedPlaylistEvent event =
+        new FollowingPostedPlaylistEvent(creatorId, playlistId, playlistName, true);
+
+    FollowResponse follower1 = new FollowResponse(UUID.randomUUID(), "user1", "img1", null, null);
+    FollowResponse follower2 = new FollowResponse(UUID.randomUUID(), "user2", "img2", null, null);
+    when(followService.getFollowing(creatorId)).thenReturn(List.of(follower1, follower2));
+
+    // when
+    listener.onFollowingPostedPlaylist(event);
+
+    // then
+    ArgumentCaptor<NotificationDto> captor = ArgumentCaptor.forClass(NotificationDto.class);
+    //---------------------------------follower1, follower2
+    verify(notificationService, times(2)).sendNotification(captor.capture());
+
+    List<NotificationDto> dtos = captor.getAllValues();
+    assertThat(dtos).hasSize(2);
+    assertThat(dtos).extracting(NotificationDto::getReceiverId).containsExactlyInAnyOrder(follower1.id(), follower2.id());
+    assertThat(dtos).allSatisfy(dto -> {
+      assertThat(dto.getNotificationType()).isEqualTo(NotificationType.FOLLOWING_POSTED_PLAYLIST);
+      assertThat(dto.getContent()).contains(playlistName);
+      assertThat(dto.getContent()).contains(creatorId.toString());
+    });
+
+    verifyNoMoreInteractions(notificationService);
+  }
+
+  @DisplayName("비공개 플리면 아무에게도 안 보낸다")
+  @Test
+  void onFollowingPostedPlaylist_private_playlist_no_notification() {
+    // given
+    UUID creatorId = UUID.randomUUID();
+    FollowingPostedPlaylistEvent event =
+        new FollowingPostedPlaylistEvent(creatorId, UUID.randomUUID(), "secret", false);
+
+    // when
+    listener.onFollowingPostedPlaylist(event);
+
+    // then
+    verifyNoInteractions(notificationService);
+    verifyNoInteractions(followService); // 비공개면 팔로워 조회 자체를 안 함
+  }
+
+  @DisplayName("팔로워가 없으면 알림 전송 안 함")
+  @Test
+  void onFollowingPostedPlaylist_no_followers() {
+    // given
+    UUID creatorId = UUID.randomUUID();
+    FollowingPostedPlaylistEvent event =
+        new FollowingPostedPlaylistEvent(creatorId, UUID.randomUUID(), "empty world", true);
+
+    when(followService.getFollowing(creatorId)).thenReturn(List.of());
+
+    // when
+    listener.onFollowingPostedPlaylist(event);
+
+    // then
+    verify(followService).getFollowing(creatorId);
+    verifyNoInteractions(notificationService);
+  }
+}
+

--- a/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
@@ -18,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team03.mopl.domain.follow.dto.FollowResponse;
 import team03.mopl.domain.follow.service.FollowService;
 import team03.mopl.domain.notification.dto.NotificationDto;
-import team03.mopl.domain.notification.entity.Notification;
 import team03.mopl.domain.notification.entity.NotificationType;
 import team03.mopl.domain.notification.events.FollowingPostedPlaylistEvent;
 import team03.mopl.domain.notification.events.PlaylistSubscribedEvent;

--- a/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
@@ -109,10 +109,11 @@ class NotificationEventListenerTest {
   void onFollowingPostedPlaylist_public_playlist_sends_notifications() {
     // given
     UUID creatorId = UUID.randomUUID();
+    String creatorName = "creator";
     UUID playlistId = UUID.randomUUID();
     String playlistName = "새 플리!";
     FollowingPostedPlaylistEvent event =
-        new FollowingPostedPlaylistEvent(creatorId, playlistId, playlistName, true);
+        new FollowingPostedPlaylistEvent(creatorId, creatorName, playlistId, playlistName, true);
 
     FollowResponse follower1 = new FollowResponse(UUID.randomUUID(), "user1", "img1", null, null);
     FollowResponse follower2 = new FollowResponse(UUID.randomUUID(), "user2", "img2", null, null);
@@ -143,8 +144,9 @@ class NotificationEventListenerTest {
   void onFollowingPostedPlaylist_private_playlist_no_notification() {
     // given
     UUID creatorId = UUID.randomUUID();
+    String creatorName = "creator";
     FollowingPostedPlaylistEvent event =
-        new FollowingPostedPlaylistEvent(creatorId, UUID.randomUUID(), "secret", false);
+        new FollowingPostedPlaylistEvent(creatorId, creatorName, UUID.randomUUID(), "secret", false);
 
     // when
     listener.onFollowingPostedPlaylist(event);
@@ -159,8 +161,9 @@ class NotificationEventListenerTest {
   void onFollowingPostedPlaylist_no_followers() {
     // given
     UUID creatorId = UUID.randomUUID();
+    String creatorName = "creator";
     FollowingPostedPlaylistEvent event =
-        new FollowingPostedPlaylistEvent(creatorId, UUID.randomUUID(), "empty world", true);
+        new FollowingPostedPlaylistEvent(creatorId, creatorName, UUID.randomUUID(), "empty world", true);
 
     when(followService.getFollowing(creatorId)).thenReturn(List.of());
 

--- a/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
+++ b/src/test/java/team03/mopl/domain/notification/NotificationEventListenerTest.java
@@ -84,9 +84,9 @@ class NotificationEventListenerTest {
     UUID playlistId   = UUID.randomUUID();
     UUID ownerId      = UUID.randomUUID();
     UUID subscriberId = UUID.randomUUID();
-
+    String title = "title";
     PlaylistSubscribedEvent event =
-        new PlaylistSubscribedEvent(playlistId, ownerId, subscriberId);
+        new PlaylistSubscribedEvent(playlistId, ownerId, title, subscriberId);
 
     // when
     listener.onPlaylistSubscribed(event);


### PR DESCRIPTION
## 🛰️ Issue Number
- #223 

## 🪐 작업 내용

- 플레이리스트 업데이트 시 구독자에게 알림 전송
- 플레이리스트가 구독되면 플레이리스트 소유자에게 알림
- 플리 생성 시 플리 생성자를 팔로우하고 있던 팔로워에게 알림 전송

- 커서 페이징 유틸 사용으로 수정

- 이전 피드백 
  - DmRepositoryCustomTest 의 QuerydslConfig 직접 생성해 쓰던 것 수정
## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?