### PR TITLE
refactor: 스포츠 컨텐츠 데이터 적재 시간 변경, 적재 규칙 변경, 로그 위치 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/content/batch/launcher/SportsJobScheduler.java
+++ b/src/main/java/team03/mopl/domain/content/batch/launcher/SportsJobScheduler.java
@@ -25,7 +25,7 @@ public class SportsJobScheduler {
     this.sportsJob = sportsJob;
   }
 
-  @Scheduled(cron = "0 0 4 * * *")
+  @Scheduled(cron = "0 30 14-18 * * *", zone = "Asia/Seoul")
   public void runSportsJob() {
     JobParameters jobParameters = new JobParametersBuilder()
         .addLong("timestamp", System.currentTimeMillis())

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
@@ -5,19 +5,29 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.ItemProcessor;
 import team03.mopl.domain.content.Content;
 import team03.mopl.domain.content.ContentType;
 import team03.mopl.common.util.NormalizerUtil;
+import team03.mopl.domain.content.repository.ContentRepository;
 
 @Slf4j
+@RequiredArgsConstructor
 public class SportsApiProcessor implements ItemProcessor<SportsItemDto, Content> {
+
+  private final ContentRepository contentRepository;
 
   @Override
   public Content process(SportsItemDto item) throws Exception {
     log.info("SportsApiProcessor - SPORTS 아이템 → 컨텐츠 변환 시작 : fileName={}",
         item.getStrFilename());
+
+    if (contentRepository.existsByTitle(item.getStrFilename())) {
+      log.debug("이미 존재하는 컨텐츠입니다.: item.getStrFilename()={}", item.getStrFilename());
+      return null;
+    }
 
     // 1. description 생성
     StringBuilder description = new StringBuilder();

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiProcessor.java
@@ -71,6 +71,11 @@ public class SportsApiProcessor implements ItemProcessor<SportsItemDto, Content>
     if (item.getStrVideo() != null) {
       strVideo = item.getStrVideo();
     }
+
+    if (strVideo.isEmpty()) {
+      log.debug("YouTube URL 부재로 스킵: item.getStrFilename()={}", item.getStrFilename());
+      return null;
+    }
     log.debug("비디오 URL 확인: strVideo={}", strVideo);
 
     // 5. content 객체 생성및 반환

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiReader.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsApiReader.java
@@ -18,7 +18,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class SportsApiReader implements ItemStreamReader<SportsItemDto> {
 
   private final RestTemplate restTemplate;
-  private final List<SportsApiRequestInfo> apiRequestInfos;
+  private List<SportsApiRequestInfo> apiRequestInfos;
   private final String baseUrl;
   private int nextRequestIndex = 0;
   private List<SportsItemDto> sportsItemDtos;
@@ -26,7 +26,6 @@ public class SportsApiReader implements ItemStreamReader<SportsItemDto> {
 
   public SportsApiReader(RestTemplate restTemplate, String baseUrl) {
     this.restTemplate = restTemplate;
-    this.apiRequestInfos = buildApiRequestInfo();
     this.baseUrl = baseUrl;
     this.sportsItemDtos = new ArrayList<>();
   }
@@ -119,6 +118,7 @@ public class SportsApiReader implements ItemStreamReader<SportsItemDto> {
    */
   @Override
   public void open(ExecutionContext executionContext) throws ItemStreamException {
+    this.apiRequestInfos = buildApiRequestInfo();
     if (executionContext.containsKey("nextRequestIndex")) {
       this.nextRequestIndex = executionContext.getInt("nextRequestIndex");
       log.info("SportsApiReader - SPORTS API 데이터 읽기 재시작: nextRequestIndex={}",

--- a/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
+++ b/src/main/java/team03/mopl/domain/content/batch/sports/SportsBatchConfig.java
@@ -1,9 +1,7 @@
 package team03.mopl.domain.content.batch.sports;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.batch.item.ItemProcessor;
@@ -15,12 +13,14 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.client.RestTemplate;
 import team03.mopl.domain.content.Content;
+import team03.mopl.domain.content.repository.ContentRepository;
 import team03.mopl.domain.curation.CurationJobListener;
 
 @Configuration
 @RequiredArgsConstructor
 public class SportsBatchConfig {
 
+  private final ContentRepository contentRepository;
   private final RestTemplate restTemplate;
   private final PlatformTransactionManager transactionManager;
   private final ItemWriter<Content> itemWriter;
@@ -62,6 +62,6 @@ public class SportsBatchConfig {
 
   @Bean
   public ItemProcessor<SportsItemDto, Content> sportsProcessor(){
-    return new SportsApiProcessor();
+    return new SportsApiProcessor(contentRepository);
   }
 }

--- a/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
+++ b/src/main/java/team03/mopl/domain/content/repository/ContentRepository.java
@@ -48,4 +48,6 @@ public interface ContentRepository extends JpaRepository<Content, UUID>, Content
 
   @Query("SELECT c FROM Content c ORDER BY c.id LIMIT :limit OFFSET :offset")
   List<Content> findAllWithOffset(@Param("offset") int offset, @Param("limit") int limit);
+
+  boolean existsByTitle(String title);
 }


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용

### 1. 스포츠 데이터 적재 시간 변경
한국 시각 새벽 4시 → 오후 2시 ~ 6시의 30분 시각 마다

### 2. 스포츠 데이터 적재시 중복 적재 하지 않는 기능
<img width="2048" height="345" alt="image" src="https://github.com/user-attachments/assets/550b49f6-ab89-4716-9cfe-d5dc365ed3c3" />
존재하는 컨텐츠일시 적재하지 않는다.

### 3.  스포츠 데이터 적재시 URL이 없다면 적재 하지 않는 기능
<img width="2048" height="320" alt="image" src="https://github.com/user-attachments/assets/6ba4fd74-938d-409e-beff-d62ddce701df" />
URL이 없다면 적재하지 않는다

### 4. buildApiRequestInfo() 초기화 위치 변경

스포츠 주기 적재 API의 yesterday 로그가 애플리케이션을 띄울 때 단 한 번만 발생하는 문제*

*빈 생성 주기와 관련: 애플리케이션이 시작될 때 모든 빈을 생성하는데, 이때 SportsApiReader 인스턴스를 생성하기 위해 생성자를 불러오면서 buildApiRequestInfo() 메소드를 호출한하기 때문에 발생한 문제

<img width="1743" height="1263" alt="image" src="https://github.com/user-attachments/assets/8e9ba870-04ff-4c76-8d98-adcea269df70" />
<img width="1761" height="717" alt="image" src="https://github.com/user-attachments/assets/498c6bf2-05ef-4c23-ab27-54dfccbd2009" />

애플리케이션 시작시 로그가 찍히고, 스포츠 데이터 적재 잡이 실행될 땐 로그가 찍히지 않는다.

-> buildApiRequestInfo() 초기화: 생성자 → open() 메서드로 위치 변경

<img width="2026" height="465" alt="image" src="https://github.com/user-attachments/assets/457433ca-5e39-4616-b77b-d1596bb0e42b" />

스포츠 데이터 적재 잡이 실행될 때 로그가 찍힌다.


## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?