### PR TITLE
chore: openSearch에 접근할 수 있도록 설정 추가

### DIFF
--- a/ecs/task-definition.json
+++ b/ecs/task-definition.json
@@ -17,7 +17,12 @@
         }
       ],
       "essential": true,
-      "environment": [],
+      "environment": [
+        {
+          "name": "OPENSEARCH_ENDPOINT",
+          "value": "https://vpc-mopl-search-domain-axi4bgbebjqschluvclyxi5ymu.ap-northeast-2.es.amazonaws.com"
+        }
+      ],
       "environmentFiles": [
         {
           "value": "arn:aws:s3:::mopl-03-bucket/mopl.env",
@@ -41,6 +46,7 @@
     }
   ],
   "family": "mopl-app-task",
+  "taskRoleArn": "arn:aws:iam::112555930244:role/MoplAppTaskRole",
   "executionRoleArn": "arn:aws:iam::112555930244:role/ecsTaskExecutionRole",
   "networkMode": "bridge",
   "revision": 2,


### PR DESCRIPTION
## 🛰️ Issue Number



## 🪐 작업 내용

**task-definition**

- environment: AWS 오픈서치와 연결할 수 있는 엔드포인트를 환경변수(key-value)로 지정
- taskRoleArn: AWS 오픈서치에 HTTP 요청을 보낼 수 있도록 하는 컨테이너의 IAM역할 지정

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?