### PR TITLE
fix: dmService의 자신이 보낸 메시지에 대해서 읽음처리

### DIFF
--- a/src/main/java/team03/mopl/common/config/AsyncConfig.java
+++ b/src/main/java/team03/mopl/common/config/AsyncConfig.java
@@ -4,7 +4,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;

--- a/src/main/java/team03/mopl/common/config/AsyncConfig.java
+++ b/src/main/java/team03/mopl/common/config/AsyncConfig.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;

--- a/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
@@ -51,25 +51,20 @@ public class DmServiceImpl implements DmService {
 
     Dm dm = new Dm(sendDmDto.getSenderId(), sendDmDto.getContent());
     dm.setDmRoom(dmRoom); // 연관관계 설정
+    dm.readDm(sendDmDto.getSenderId());
 
     // 알림 전송 추가
     if (dmRoom.getSenderId().equals(sendDmDto.getSenderId())) {
-      UUID senderId = sendDmDto.getSenderId();
       UUID receiverId = dmRoom.getReceiverId(); // dmRoom의 senderId 로 등록된 사람 == dm 받는 사람
       notificationService.sendNotification(new NotificationDto(receiverId, NotificationType.DM_RECEIVED, sendDmDto.getContent()));
-      dm.readDm(senderId);
     } else if (dmRoom.getReceiverId().equals(sendDmDto.getSenderId())) {
-      UUID senderId = sendDmDto.getSenderId();
       UUID receiverId = dmRoom.getSenderId();
       notificationService.sendNotification(new NotificationDto(receiverId, NotificationType.DM_RECEIVED, sendDmDto.getContent()));
-      dm.readDm(senderId);
-      readAll(dmRoom.getId(), senderId);
     } else {
       throw new NoOneMatchInDmRoomException();
     }
 
     Dm savedDm = dmRepository.save(dm);
-
     log.info("sendDm - DM 전송 완료: dmId={}", savedDm.getId());
     return DmDto.from(savedDm);
   }


### PR DESCRIPTION
## 🛰️ Issue Number

- #254 

## 🪐 작업 내용
### dmService 에서 sendDm 부분에 자신이 보낸 DM에 대해 읽기 로직이 추가되도록 수정했습니다.

### 다만 테스트 오류는 계속 나고 있습니다 ㅠㅜ

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?