### PR TITLE
feat: 채팅방에 상대방 들어와 있을 때 읽음 처리 로직 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
@@ -39,6 +39,7 @@ public class DmServiceImpl implements DmService {
   private final NotificationService notificationService;
   private final ObjectMapper objectMapper;
   private final DmRepositoryCustom dmRepositoryCustom;
+  private final PresenceTracker presenceTracker;
 
   @Override
   @Transactional
@@ -57,9 +58,15 @@ public class DmServiceImpl implements DmService {
     if (dmRoom.getSenderId().equals(sendDmDto.getSenderId())) {
       UUID receiverId = dmRoom.getReceiverId(); // dmRoom의 senderId 로 등록된 사람 == dm 받는 사람
       notificationService.sendNotification(new NotificationDto(receiverId, NotificationType.DM_RECEIVED, sendDmDto.getContent()));
+      if (presenceTracker.isInRoom(receiverId, dmRoom.getId())) {
+        dm.readDm(receiverId);
+      }
     } else if (dmRoom.getReceiverId().equals(sendDmDto.getSenderId())) {
       UUID receiverId = dmRoom.getSenderId();
       notificationService.sendNotification(new NotificationDto(receiverId, NotificationType.DM_RECEIVED, sendDmDto.getContent()));
+      if (presenceTracker.isInRoom(receiverId, dmRoom.getId())) {
+        dm.readDm(receiverId);
+      }
     } else {
       throw new NoOneMatchInDmRoomException();
     }

--- a/src/main/java/team03/mopl/domain/dm/service/PresenceTracker.java
+++ b/src/main/java/team03/mopl/domain/dm/service/PresenceTracker.java
@@ -1,0 +1,55 @@
+package team03.mopl.domain.dm.service;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team03.mopl.common.exception.user.UserNotFoundException;
+import team03.mopl.domain.user.User;
+import team03.mopl.domain.user.UserRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PresenceTracker {
+  private final UserRepository userRepository;
+  // userId → 접속 중인 roomId 목록
+  private final ConcurrentMap<UUID, Set<UUID>> userRoomMap = new ConcurrentHashMap<>();
+
+  // 채팅방 입장
+  public void enterRoom(String username, UUID roomId) {
+    User user = userRepository.findByEmail(username).orElseThrow(UserNotFoundException::new);
+    userRoomMap.computeIfAbsent(user.getId(), k -> ConcurrentHashMap.newKeySet()).add(roomId);
+  }
+
+  // 채팅방 퇴장
+  public void exitRoom(String username, UUID roomId) {
+    User user = userRepository.findByEmail(username).orElseThrow(UserNotFoundException::new);
+    Set<UUID> rooms = userRoomMap.get(user.getId());
+    if (rooms != null) {
+      rooms.remove(roomId);
+      if (rooms.isEmpty()) {
+        userRoomMap.remove(user.getId());
+      }
+    }
+  }
+
+  // 해당 사용자가 해당 방에 접속해 있는지?
+  public boolean isInRoom(UUID userId, UUID roomId) {
+    return userRoomMap.getOrDefault(userId, Collections.emptySet()).contains(roomId);
+  }
+
+  // 모든 정보 제거 (예: WebSocket 연결 끊김)
+  public void clearUser(UUID userId) {
+    userRoomMap.remove(userId);
+  }
+
+  // 디버깅용: 현재 접속자 전체 확인
+  public Map<UUID, Set<UUID>> getAllPresence() {
+    return Collections.unmodifiableMap(userRoomMap);
+  }
+}
+

--- a/src/test/java/team03/mopl/domain/dm/controller/DmWebSocketControllerTest.java
+++ b/src/test/java/team03/mopl/domain/dm/controller/DmWebSocketControllerTest.java
@@ -78,7 +78,7 @@ class DmWebSocketControllerTest {
 
     User user = User.builder()
         .id(userId)
-        .email("user@test.com")
+        .email(email)
         .name("user")
         .password("pw")
         .build();

--- a/src/test/java/team03/mopl/domain/dm/controller/DmWebSocketControllerTest.java
+++ b/src/test/java/team03/mopl/domain/dm/controller/DmWebSocketControllerTest.java
@@ -1,13 +1,17 @@
 package team03.mopl.domain.dm.controller;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.security.Principal;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -16,18 +20,22 @@ import team03.mopl.domain.dm.dto.DmRequest;
 import team03.mopl.domain.dm.entity.Dm;
 import team03.mopl.domain.dm.entity.DmRoom;
 import team03.mopl.domain.dm.service.DmService;
+import team03.mopl.domain.dm.service.PresenceTracker;
+import team03.mopl.domain.user.User;
+import team03.mopl.domain.user.UserRepository;
 
 class DmWebSocketControllerTest {
 
   private DmService dmService;
   private SimpMessagingTemplate simpMessagingTemplate;
   private DmWebSocketController controller;
+  private PresenceTracker presenceTracker;
 
   @BeforeEach
   void setUp() {
     dmService = mock(DmService.class);
     simpMessagingTemplate = mock(SimpMessagingTemplate.class);
-    controller = new DmWebSocketController(simpMessagingTemplate, dmService);
+    controller = new DmWebSocketController(simpMessagingTemplate, dmService, presenceTracker);
   }
 
   @Test
@@ -60,5 +68,30 @@ class DmWebSocketControllerTest {
     ));
     verify(simpMessagingTemplate).convertAndSend(eq("/topic/dm/" + roomId), eq(dmDto));
 
+  }
+  @Test
+  @DisplayName("DmRoom 입장 시 username을 기반으로 presenceTracker가 호출되는지 확인")
+  void enterRoomTest() {
+    String email = "testuser@mopl.com";
+    UUID roomId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    User user = User.builder()
+        .id(userId)
+        .email("user@test.com")
+        .name("user")
+        .password("pw")
+        .build();
+
+    Principal principal = mock(Principal.class);
+    when(principal.getName()).thenReturn(email);
+
+    UserRepository userRepository = mock(UserRepository.class);
+    when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+
+    PresenceTracker presenceTracker = new PresenceTracker(userRepository);
+    presenceTracker.enterRoom(email, roomId);
+
+    assertTrue(presenceTracker.isInRoom(userId, roomId));
   }
 }

--- a/src/test/java/team03/mopl/domain/dm/service/DmServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/dm/service/DmServiceImplTest.java
@@ -56,6 +56,8 @@ class DmServiceImplTest {
   private NotificationService notificationService;
   @Mock
   private DmRepositoryCustom dmRepositoryCustom;
+  @Mock
+  private PresenceTracker presenceTracker;
 
   @InjectMocks
   private DmServiceImpl dmService;
@@ -87,7 +89,7 @@ class DmServiceImplTest {
     given(dmRoomRepository.findById(roomId)).willReturn(Optional.of(dmRoom_SenderEqualDmRoomSenderUserA));
     given(dmRepository.save(any(Dm.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
-
+    given(presenceTracker.isInRoom(any(), any())).willReturn(false);
     // when
     var result = dmService.sendDm(new SendDmDto(userA, roomId, content));
 
@@ -113,7 +115,7 @@ class DmServiceImplTest {
     given(dmRoomRepository.findById(roomId)).willReturn(Optional.of(dmRoom_SenderEqualDmRoomReceiverUserB));
     given(dmRepository.save(any(Dm.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
-
+    given(presenceTracker.isInRoom(any(), any())).willReturn(false);
     // when
     var result = dmService.sendDm(new SendDmDto(userB, roomId, content));
 


### PR DESCRIPTION
## 🛰️ Issue Number

- #274 

## 🪐 작업 내용
UserA와 UserB가 채팅방에 있을 때, UserB가 채팅방에 있음에도 불구하고 
UserA가 메시지를 보낼 때 UserB가 읽었음을 체크하지 못하는 현상 발생

```
@MessageMapping("/dmRooms/{roomId}/enter}")
  public void enterRoom(@DestinationVariable String roomId, Principal principal) {
    presenceTracker.enterRoom(principal.getName(),UUID.fromString(roomId));
    log.info("enterRoom - 사용자 채팅방 접속: userName={}, roomId={}", principal.getName(), roomId);
  }
  @MessageMapping("/dmRooms/{roomId}/exit")
  public void exitRoom(@DestinationVariable String roomId, Principal principal) {
    presenceTracker.exitRoom(principal.getName(), UUID.fromString(roomId));
    log.info("exitRoom - 사용자 채팅방 퇴장: userName={}, roomId={}", principal.getName(), roomId);
  }
```

통신방에 들어올 때부터 Map<RoomId, UserId> 로 체크
들어와 있다면 sendDm 할 때 읽음 로직 포함해서 돌림

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?