### PR TITLE
bug: dmRoom updatedAt 필드 추가 및 최신순 정렬

### DIFF
--- a/init/schema.sql
+++ b/init/schema.sql
@@ -169,6 +169,7 @@ CREATE TABLE "dm_rooms"
     "sender_id"   UUID                    NULL,
     "receiver_id" UUID                    NULL,
     "created_at"  TIMESTAMP DEFAULT now() NOT NULL,
+    "updated_at"   TIMESTAMP DEFAULT now() NOT NULL,
     UNIQUE ("sender_id", "receiver_id"),
     FOREIGN KEY ("sender_id") REFERENCES "users" ("id"),
     FOREIGN KEY ("receiver_id") REFERENCES "users" ("id")

--- a/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
@@ -31,7 +31,7 @@ public class DmRoomDto {
   private LocalDateTime createdAt;
 
   @Schema(description = "채팅방 업데이트 시간", example = "2024-12-01T10:30:00")
-  private LocalDateTime updatedAt;
+  private LocalDateTime lastMessageAt;
 
   @Schema(description = "마지막 메시지 내용", example = "지금 확인할게요")
   private String lastMessage;
@@ -40,17 +40,17 @@ public class DmRoomDto {
   private long newMessageCount;
 
   public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt,
-      LocalDateTime updatedAt) {
+      LocalDateTime lastMessageAt) {
     this.id = id;
     this.senderId = senderId;
     this.receiverId = receiverId;
     this.senderName = senderName;
     this.receiverName = receiverName;
     this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
+    this.lastMessageAt = lastMessageAt;
   }
 
-  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt, LocalDateTime updatedAt,
+  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt, LocalDateTime lastMessageAt,
       String lastMessage, long newMessageCount) {
     this.id = id;
     this.senderId = senderId;
@@ -58,18 +58,18 @@ public class DmRoomDto {
     this.senderName = senderName;
     this.receiverName = receiverName;
     this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
+    this.lastMessageAt = lastMessageAt;
     this.lastMessage = lastMessage;
     this.newMessageCount = newMessageCount;
   }
 
   public static DmRoomDto from(String lastMessage, int unreadCount, String senderName, String receiverName, DmRoom room) {
-    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getUpdatedAt(),
+    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getLastMessageAt(),
         lastMessage, unreadCount);
   }
 
 
   public static DmRoomDto from(String senderName, String receiverName, DmRoom room) {
-    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getUpdatedAt());
+    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getLastMessageAt());
   }
 }

--- a/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
+++ b/src/main/java/team03/mopl/domain/dm/dto/DmRoomDto.java
@@ -30,55 +30,46 @@ public class DmRoomDto {
   @Schema(description = "채팅방 생성 시간", example = "2024-12-01T10:00:00")
   private LocalDateTime createdAt;
 
+  @Schema(description = "채팅방 업데이트 시간", example = "2024-12-01T10:30:00")
+  private LocalDateTime updatedAt;
+
   @Schema(description = "마지막 메시지 내용", example = "지금 확인할게요")
   private String lastMessage;
 
   @Schema(description = "읽지 않은 메시지 수", example = "3")
   private long newMessageCount;
 
-  public DmRoomDto(UUID id, UUID senderId, UUID receiverId,  String senderName, String receiverName, LocalDateTime createdAt) {
+  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt,
+      LocalDateTime updatedAt) {
     this.id = id;
     this.senderId = senderId;
     this.receiverId = receiverId;
     this.senderName = senderName;
     this.receiverName = receiverName;
     this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
   }
 
-  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt, String lastMessage,
-      long newMessageCount) {
+  public DmRoomDto(UUID id, UUID senderId, UUID receiverId, String senderName, String receiverName, LocalDateTime createdAt, LocalDateTime updatedAt,
+      String lastMessage, long newMessageCount) {
     this.id = id;
     this.senderId = senderId;
     this.receiverId = receiverId;
     this.senderName = senderName;
     this.receiverName = receiverName;
     this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
     this.lastMessage = lastMessage;
     this.newMessageCount = newMessageCount;
   }
 
-  public static DmRoomDto from(String lastMessage, int unreadCount,String senderName, String receiverName, DmRoom room) {
-    return new DmRoomDto(
-        room.getId(),
-        room.getSenderId(),
-        room.getReceiverId(),
-        senderName,
-        receiverName,
-        room.getCreatedAt(),
-        lastMessage,
-        unreadCount
-    );
+  public static DmRoomDto from(String lastMessage, int unreadCount, String senderName, String receiverName, DmRoom room) {
+    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getUpdatedAt(),
+        lastMessage, unreadCount);
   }
 
 
   public static DmRoomDto from(String senderName, String receiverName, DmRoom room) {
-    return new DmRoomDto(
-        room.getId(),
-        room.getSenderId(),
-        room.getReceiverId(),
-        senderName,
-        receiverName,
-        room.getCreatedAt()
-    );
+    return new DmRoomDto(room.getId(), room.getSenderId(), room.getReceiverId(), senderName, receiverName, room.getCreatedAt(), room.getUpdatedAt());
   }
 }

--- a/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
+++ b/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -44,6 +45,10 @@ public class DmRoom {
   @Column(name = "created_at", updatable = false, nullable = false)
   private LocalDateTime createdAt;
 
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private LocalDateTime updatedAt;
+
   @ElementCollection
   @CollectionTable(
       name = "dm_room_out_users",
@@ -61,6 +66,9 @@ public class DmRoom {
   public DmRoom(UUID senderId, UUID receiverId) {
     this.senderId = senderId;
     this.receiverId = receiverId;
+  }
+  public void touchUpdatedAt(LocalDateTime updatedAt) {
+    this.updatedAt = updatedAt;
   }
   /*public boolean nobodyInRoom() {
     if( senderId == null && receiverId == null ) {

--- a/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
+++ b/src/main/java/team03/mopl/domain/dm/entity/DmRoom.java
@@ -46,8 +46,8 @@ public class DmRoom {
   private LocalDateTime createdAt;
 
   @LastModifiedDate
-  @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
+  @Column(name = "last_Message_At")
+  private LocalDateTime lastMessageAt;
 
   @ElementCollection
   @CollectionTable(
@@ -67,8 +67,8 @@ public class DmRoom {
     this.senderId = senderId;
     this.receiverId = receiverId;
   }
-  public void touchUpdatedAt(LocalDateTime updatedAt) {
-    this.updatedAt = updatedAt;
+  public void touchLastMessageAt(LocalDateTime lastMessageAt) {
+    this.lastMessageAt = lastMessageAt;
   }
   /*public boolean nobodyInRoom() {
     if( senderId == null && receiverId == null ) {

--- a/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
@@ -123,11 +123,8 @@ public class DmRoomServiceImpl implements DmRoomService {
 
       dmRoomDtos.add(DmRoomDto.from(content, unreadCount, sender.getName(), receiver.getName(), dmRoom));
     }
-    //updateAt순으로 정렬
-    dmRoomDtos.sort(Comparator.comparing(DmRoomDto::getUpdatedAt).reversed());
-    for (DmRoomDto dmRoomDto : dmRoomDtos) {
-      System.out.println("dmRoomDto.getUpdatedAt() = " + dmRoomDto.getUpdatedAt());
-    }
+    //LastMessageAt 순으로 정렬
+    dmRoomDtos.sort(Comparator.comparing(DmRoomDto::getLastMessageAt).reversed());
     return dmRoomDtos;
   }
 

--- a/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmRoomServiceImpl.java
@@ -1,6 +1,7 @@
 package team03.mopl.domain.dm.service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -121,6 +122,11 @@ public class DmRoomServiceImpl implements DmRoomService {
       User receiver = userRepository.findById(dmRoom.getReceiverId()).orElseThrow(UserNotFoundException::new);
 
       dmRoomDtos.add(DmRoomDto.from(content, unreadCount, sender.getName(), receiver.getName(), dmRoom));
+    }
+    //updateAt순으로 정렬
+    dmRoomDtos.sort(Comparator.comparing(DmRoomDto::getUpdatedAt).reversed());
+    for (DmRoomDto dmRoomDto : dmRoomDtos) {
+      System.out.println("dmRoomDto.getUpdatedAt() = " + dmRoomDto.getUpdatedAt());
     }
     return dmRoomDtos;
   }

--- a/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
@@ -66,7 +66,7 @@ public class DmServiceImpl implements DmService {
     }
 
     Dm savedDm = dmRepository.save(dm);
-    dmRoom.touchUpdatedAt(LocalDateTime.now());
+    dmRoom.touchLastMessageAt(LocalDateTime.now());
     log.info("sendDm - DM 전송 완료: dmId={}", savedDm.getId());
     return DmDto.from(savedDm);
   }

--- a/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/dm/service/DmServiceImpl.java
@@ -2,6 +2,7 @@ package team03.mopl.domain.dm.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
@@ -65,6 +66,7 @@ public class DmServiceImpl implements DmService {
     }
 
     Dm savedDm = dmRepository.save(dm);
+    dmRoom.touchUpdatedAt(LocalDateTime.now());
     log.info("sendDm - DM 전송 완료: dmId={}", savedDm.getId());
     return DmDto.from(savedDm);
   }

--- a/src/test/java/team03/mopl/domain/dm/controller/DmRoomControllerTest.java
+++ b/src/test/java/team03/mopl/domain/dm/controller/DmRoomControllerTest.java
@@ -58,7 +58,7 @@ class DmRoomControllerTest {
     UUID userB = UUID.randomUUID();
     String userAName = "UserA";
     String userBName = "UserB";
-    DmRoomDto dto = new DmRoomDto(roomId, userA, userB, userAName, userBName, LocalDateTime.now());
+    DmRoomDto dto = new DmRoomDto(roomId, userA, userB, userAName, userBName, LocalDateTime.now(), LocalDateTime.now());
     given(dmRoomService.getRoom(roomId)).willReturn(dto);
 
     mockMvc.perform(get("/api/dmRooms/{dmRoomId}", roomId))
@@ -88,7 +88,7 @@ class DmRoomControllerTest {
 
 
     given(dmRoomService.findOrCreateRoom(userA, userB))
-        .willReturn(new DmRoomDto(roomId, userA, userB, userAName, userBName, LocalDateTime.now()));
+        .willReturn(new DmRoomDto(roomId, userA, userB, userAName, userBName, LocalDateTime.now(), LocalDateTime.now()));
 
     mockMvc.perform(get("/api/dmRooms/userRoom")
             .with(user(principal))
@@ -105,8 +105,8 @@ class DmRoomControllerTest {
     UUID roomId2 = UUID.randomUUID();
 
     List<DmRoomDto> rooms = List.of(
-        new DmRoomDto(roomId1, userId, UUID.randomUUID(), "userA", "userB", LocalDateTime.now()),
-        new DmRoomDto(roomId2, userId, UUID.randomUUID(), "userA", "userC", LocalDateTime.now())
+        new DmRoomDto(roomId1, userId, UUID.randomUUID(), "userA", "userB", LocalDateTime.now(), LocalDateTime.now()),
+        new DmRoomDto(roomId2, userId, UUID.randomUUID(), "userA", "userC", LocalDateTime.now(), LocalDateTime.now())
     );
 
     User user;

--- a/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
@@ -1,7 +1,6 @@
 package team03.mopl.domain.dm.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +9,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -29,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -272,10 +269,10 @@ class DmRoomServiceImplTest {
     // 방
     DmRoom room1 = new DmRoom(roomId1, senderId, receiverId);
     room1.getMessages().add(message1);
-    ReflectionTestUtils.setField(room1, "updatedAt", LocalDateTime.now().minusMinutes(1));
+    ReflectionTestUtils.setField(room1, "lastMessageAt", LocalDateTime.now().minusMinutes(1));
     DmRoom room2 = new DmRoom(roomId2, senderId, receiverId);
     room2.getMessages().add(message2);
-    ReflectionTestUtils.setField(room2, "updatedAt", LocalDateTime.now());
+    ReflectionTestUtils.setField(room2, "lastMessageAt", LocalDateTime.now());
     // Repository Stubbing
     given(dmRoomRepository.findBySenderIdOrReceiverId(senderId, senderId))
         .willReturn(List.of(room1, room2));
@@ -417,7 +414,7 @@ class DmRoomServiceImplTest {
 
       // createdAt, updatedAt 세팅 (i가 클수록 최신)
       ReflectionTestUtils.setField(room, "createdAt", baseTime.plusMinutes(i));
-      ReflectionTestUtils.setField(room, "updatedAt", baseTime.plusMinutes(i));
+      ReflectionTestUtils.setField(room, "lastMessageAt", baseTime.plusMinutes(i));
 
       // 메시지가 없어도 되지만, lastMessage 로직을 위해 하나라도 넣어둘 수 있습니다
       Dm dummy = new Dm(userId, "msg" + i);
@@ -454,7 +451,7 @@ class DmRoomServiceImplTest {
     DmRoomDto first = result.get(0);
     assertThat(first.getNewMessageCount()).isEqualTo(0);
     assertThat(first.getLastMessage()).isEqualTo("hello world");
-    assertThat(first.getUpdatedAt()).isEqualTo(baseTime.plusMinutes(10));
+    assertThat(first.getLastMessageAt()).isEqualTo(baseTime.plusMinutes(10));
   }
 
 }

--- a/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
@@ -11,11 +11,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -27,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -55,6 +59,7 @@ class DmRoomServiceImplTest {
   private NotificationService notificationService;
   @Mock
   private PasswordEncoder passwordEncoder;
+  @Spy
   @InjectMocks
   private DmRoomServiceImpl dmRoomService;
   @InjectMocks
@@ -267,9 +272,10 @@ class DmRoomServiceImplTest {
     // 방
     DmRoom room1 = new DmRoom(roomId1, senderId, receiverId);
     room1.getMessages().add(message1);
+    ReflectionTestUtils.setField(room1, "updatedAt", LocalDateTime.now().minusMinutes(1));
     DmRoom room2 = new DmRoom(roomId2, senderId, receiverId);
     room2.getMessages().add(message2);
-
+    ReflectionTestUtils.setField(room2, "updatedAt", LocalDateTime.now());
     // Repository Stubbing
     given(dmRoomRepository.findBySenderIdOrReceiverId(senderId, senderId))
         .willReturn(List.of(room1, room2));
@@ -295,7 +301,7 @@ class DmRoomServiceImplTest {
   }
 
   @Test
-  @DisplayName("sender 먼저 나가고 receiver는 남아있어 방유지")
+  @DisplayName("sender 먼저 나가고 receiver는 남아있어 방 유지")
   void deleteSender () {
     // given
     UUID roomId = UUID.randomUUID();
@@ -387,7 +393,10 @@ class DmRoomServiceImplTest {
     when(dmRoomRepository.findByRoomBetweenUsers(senderId, receiverId)).thenReturn(Optional.of(room));
     when(dmRoomRepository.findById(room.getId())).thenReturn(Optional.of(room));
     // Spy를 써서 reenterRoom 호출 여부/동작 확인
-    DmRoomServiceImpl spyService = Mockito.spy(dmRoomService);
+    DmRoomServiceImpl realService = new DmRoomServiceImpl(
+        dmRoomRepository, dmService, userRepository, notificationService
+    );
+    DmRoomServiceImpl spyService = Mockito.spy(realService);
 
     // when
     DmRoomDto dto = spyService.findOrCreateRoom(senderId, receiverId);
@@ -396,6 +405,61 @@ class DmRoomServiceImplTest {
     verify(spyService).reenterRoom(eq(senderId), eq(room.getId()));
     assertFalse(room.isOut(senderId));                          // outUsers 에서 제거됐는지
     Assertions.assertEquals(room.getId(), dto.getId());        // 기존 방 재사용 확인
+  }
+
+  @Test
+  @DisplayName("getAllRoomsForUser - updatedAt 순으로 내림차순 정렬되는지 테스트")
+  void getAllRoomsForUser_sortedByUpdatedAt() {
+    // 준비: userId
+    UUID userId = UUID.randomUUID();
+
+    // baseTime 기준으로 10개 방 생성
+    LocalDateTime baseTime = LocalDateTime.of(2025, 7, 25, 12, 0);
+    List<DmRoom> rooms = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      // id, sender, receiver 아무 UUID라도 상관없음
+      DmRoom room = new DmRoom(UUID.randomUUID(), userId, UUID.randomUUID());
+
+      // createdAt, updatedAt 세팅 (i가 클수록 최신)
+      ReflectionTestUtils.setField(room, "createdAt", baseTime.plusMinutes(i));
+      ReflectionTestUtils.setField(room, "updatedAt", baseTime.plusMinutes(i));
+
+      // 메시지가 없어도 되지만, lastMessage 로직을 위해 하나라도 넣어둘 수 있습니다
+      Dm dummy = new Dm(userId, "msg" + i);
+      dummy.setDmRoom(room);
+      if(i==10){
+        room.getMessages().add(new Dm(userId, "hello world"));
+      }else{
+        room.getMessages().add(dummy);
+      }
+
+      rooms.add(room);
+    }
+
+    // mock: repository, userRepository, unreadCount
+    given(dmRoomRepository.findBySenderIdOrReceiverId(any(), any())).willReturn(rooms);
+
+    // userRepository는 senderId, receiverId 둘 다 찾도록
+    for (DmRoom room : rooms) {
+      User sender = User.builder().id(room.getSenderId()).email("sender@test.com").name("sender").password("pw").build();
+      User receiver = User.builder().id(room.getReceiverId()).email("receiver@test.com").name("receiver").password("pw").build();
+
+      when(userRepository.findById(room.getSenderId()))
+          .thenReturn(Optional.of(sender));
+      when(userRepository.findById(room.getReceiverId()))
+          .thenReturn(Optional.of(receiver));
+    }
+    // unreadCount는 0으로 고정
+    doReturn(0).when(dmRoomService).getUnreadCount(any(), eq(userId));
+
+    // 실행
+    List<DmRoomDto> result = dmRoomService.getAllRoomsForUser(userId);
+
+    // 검증: 가장 첫 번째 방의 updatedAt 이 baseTime + 10분 인지 확인
+    DmRoomDto first = result.get(0);
+    assertThat(first.getNewMessageCount()).isEqualTo(0);
+    assertThat(first.getLastMessage()).isEqualTo("hello world");
+    assertThat(first.getUpdatedAt()).isEqualTo(baseTime.plusMinutes(10));
   }
 
 }

--- a/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/dm/service/DmRoomServiceImplTest.java
@@ -392,17 +392,12 @@ class DmRoomServiceImplTest {
     when(userRepository.findById(receiverId)).thenReturn(Optional.of(receiver));
     when(dmRoomRepository.findByRoomBetweenUsers(senderId, receiverId)).thenReturn(Optional.of(room));
     when(dmRoomRepository.findById(room.getId())).thenReturn(Optional.of(room));
-    // Spy를 써서 reenterRoom 호출 여부/동작 확인
-    DmRoomServiceImpl realService = new DmRoomServiceImpl(
-        dmRoomRepository, dmService, userRepository, notificationService
-    );
-    DmRoomServiceImpl spyService = Mockito.spy(realService);
 
     // when
-    DmRoomDto dto = spyService.findOrCreateRoom(senderId, receiverId);
+    DmRoomDto dto = dmRoomService.findOrCreateRoom(senderId, receiverId);
 
     // then
-    verify(spyService).reenterRoom(eq(senderId), eq(room.getId()));
+    verify(dmRoomService).reenterRoom(eq(senderId), eq(room.getId()));
     assertFalse(room.isOut(senderId));                          // outUsers 에서 제거됐는지
     Assertions.assertEquals(room.getId(), dto.getId());        // 기존 방 재사용 확인
   }

--- a/src/test/java/team03/mopl/domain/watchroom/repository/WatchRoomParticipantRepositoryTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/repository/WatchRoomParticipantRepositoryTest.java
@@ -513,7 +513,7 @@ class WatchRoomParticipantRepositoryTest {
       assertEquals("테스트시청방9", result.get(0).getWatchRoom().getTitle());
     }
 
-    /*@Test
+    @Test
     @DisplayName("컨텐츠 제목에 검색어가 있음, createdAt, ASC, Cursor not null, size 10, 결과는 5")
     void whenWatchRoomContentTitleContainsKeyword() {
 
@@ -537,7 +537,7 @@ class WatchRoomParticipantRepositoryTest {
       //then
       assertEquals(5, result.size());
       assertTrue(result.get(0).getContent().getTitle().contains("미"));
-    }*/
+    }
 
     @Test
     @DisplayName("시청방 제목, 컨텐츠 제목, 소유자 이름 모두에 키워드가 들어가지 않음")

--- a/src/test/java/team03/mopl/domain/watchroom/repository/WatchRoomParticipantRepositoryTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/repository/WatchRoomParticipantRepositoryTest.java
@@ -513,7 +513,7 @@ class WatchRoomParticipantRepositoryTest {
       assertEquals("테스트시청방9", result.get(0).getWatchRoom().getTitle());
     }
 
-    @Test
+    /*@Test
     @DisplayName("컨텐츠 제목에 검색어가 있음, createdAt, ASC, Cursor not null, size 10, 결과는 5")
     void whenWatchRoomContentTitleContainsKeyword() {
 
@@ -537,7 +537,7 @@ class WatchRoomParticipantRepositoryTest {
       //then
       assertEquals(5, result.size());
       assertTrue(result.get(0).getContent().getTitle().contains("미"));
-    }
+    }*/
 
     @Test
     @DisplayName("시청방 제목, 컨텐츠 제목, 소유자 이름 모두에 키워드가 들어가지 않음")


### PR DESCRIPTION
## 🛰️ Issue Number

- #278 

## 🪐 작업 내용
- DmRoom 에 updatedAt 필드 추가
- 스키마 업데이트
- sendDm 시 updatedAt 수정 -> getAllRoomsForUser 시 최신 순으로 정렬

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?