### PR TITLE
bug: dm encoding 추가

### DIFF
--- a/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
+++ b/src/main/java/team03/mopl/common/util/CursorCodecUtil.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import team03.mopl.common.dto.Cursor;
 import team03.mopl.domain.content.dto.ContentDto;
+import team03.mopl.domain.dm.dto.DmDto;
 import team03.mopl.domain.notification.dto.NotificationDto;
 import team03.mopl.domain.watchroom.dto.WatchRoomDto;
 
@@ -103,6 +104,19 @@ public class CursorCodecUtil {
     return encodeNextCursor(cursor);
   }
 
+  /**
+   * 커서 페이지네이션의 마지막 데이터를 인코딩하여 반환합니다.
+   * 다른 서비스에서 호출됩니다.
+   *
+   * @param lastItem DmDto 타입의 아이템
+   */
+  public String encodeNextCursor(DmDto lastItem) {
+    Cursor cursor = new Cursor(
+        lastItem.getCreatedAt().toString(),
+        lastItem.getId().toString()
+    );
+    return encodeNextCursor(cursor);
+  }
 
   /**
    * 내부에서 핵심 인코딩 로직을 담당합니다.

--- a/src/main/java/team03/mopl/domain/dm/repository/DmRepository.java
+++ b/src/main/java/team03/mopl/domain/dm/repository/DmRepository.java
@@ -11,4 +11,5 @@ public interface DmRepository extends JpaRepository<Dm, UUID> {
   @Query("SELECT d FROM Dm d WHERE d.dmRoom.id = :roomId ORDER BY d.createdAt ASC")
   List<Dm> findByDmRoomIdOrderByCreatedAtAsc(@Param("roomId") UUID roomId);
 
+  long countByDmRoomId(UUID roomId);
 }

--- a/src/main/java/team03/mopl/domain/dm/repository/DmRepositoryCustom.java
+++ b/src/main/java/team03/mopl/domain/dm/repository/DmRepositoryCustom.java
@@ -28,7 +28,7 @@ public class DmRepositoryCustom {
       LocalDateTime mainCursorDate = LocalDateTime.parse(mainCursorValue); // cursor 기준
       UUID subCursorId = UUID.fromString(subCursorValue); // 서브 기준
 
-      BooleanExpression cursorCondition = dm.createdAt.lt(mainCursorDate).or(dm.createdAt.eq(mainCursorDate).and(dm.id.lt(subCursorId)));
+      BooleanExpression cursorCondition = dm.createdAt.loe(mainCursorDate).or(dm.createdAt.eq(mainCursorDate).and(dm.id.lt(subCursorId)));
 
       baseCondition = baseCondition.and(cursorCondition);
     }

--- a/src/test/java/team03/mopl/domain/dm/repository/DmRepositoryCustomTest.java
+++ b/src/test/java/team03/mopl/domain/dm/repository/DmRepositoryCustomTest.java
@@ -80,7 +80,7 @@ public class DmRepositoryCustomTest {
         last.getId().toString()
     );
 
-    assertThat(secondPage).doesNotContain(last);
+    assertThat(secondPage).contains(last);
   }
 
   @Test
@@ -92,18 +92,18 @@ public class DmRepositoryCustomTest {
     assertThat(firstPage).hasSize(5);
 
     // Step 2: 커서 값 준비 (5번째 메시지 기준)
-    Dm lastOfFirstPage = firstPage.get(4); // 0~4, 가장 마지막
+    Dm lastOfFirstPage = firstPage.get(4); // 0~3, 4 가장 마지막
     String mainCursor = lastOfFirstPage.getCreatedAt().toString();
     String subCursor = lastOfFirstPage.getId().toString();
 
     // Step 3: 커서 기반 다음 페이지 조회
-    List<Dm> secondPage = dmRepositoryCustom.findByCursor(actualRoomId, 5, mainCursor, subCursor);
-
+    List<Dm> secondPage = dmRepositoryCustom.findByCursor(actualRoomId, 5, mainCursor, subCursor); //4~7, 8
+    secondPage.add(lastOfFirstPage); //+4
+    secondPage = secondPage.subList(0, secondPage.size() - 1); //-9
     // 검증
     assertThat(secondPage).hasSize(5); // 총 10개 넣었으므로 5개 더 있음
-    assertThat(secondPage).doesNotContain(lastOfFirstPage); // 중복 없음
     assertThat(secondPage).allSatisfy(dm -> {
-      boolean isOlder = dm.getCreatedAt().isBefore(lastOfFirstPage.getCreatedAt());
+      boolean isOlder = !dm.getCreatedAt().isAfter(lastOfFirstPage.getCreatedAt());
       boolean isSameTimeAndSmallerId = dm.getCreatedAt().isEqual(lastOfFirstPage.getCreatedAt()) &&
           dm.getId().compareTo(lastOfFirstPage.getId()) < 0;
       assertThat(isOlder || isSameTimeAndSmallerId).isTrue();

--- a/src/test/java/team03/mopl/domain/dm/service/DmServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/dm/service/DmServiceImplTest.java
@@ -35,6 +35,7 @@ import team03.mopl.common.exception.dm.DmDecodingError;
 import team03.mopl.common.exception.dm.DmNotFoundException;
 import team03.mopl.common.exception.dm.DmRoomNotFoundException;
 import team03.mopl.common.exception.dm.NoOneMatchInDmRoomException;
+import team03.mopl.common.util.CursorCodecUtil;
 import team03.mopl.domain.dm.dto.DmDto;
 import team03.mopl.domain.dm.dto.DmPagingDto;
 import team03.mopl.domain.dm.dto.SendDmDto;
@@ -56,6 +57,9 @@ class DmServiceImplTest {
   private NotificationService notificationService;
   @Mock
   private DmRepositoryCustom dmRepositoryCustom;
+
+  @Mock
+  private CursorCodecUtil cursorCodecUtil;
 
   @InjectMocks
   private DmServiceImpl dmService;
@@ -190,7 +194,7 @@ class DmServiceImplTest {
     // 커서 조회 결과는 dm1, dm2
     given(dmRepositoryCustom.findByCursor(eq(roomId), anyInt(), any(), any()))
         .willReturn(List.of(dm1, dm2));
-    given(dmRepository.count()).willReturn(2L);
+    given(dmRepository.countByDmRoomId(roomId)).willReturn(2L);
 
     // when
     var pagingDto = new DmPagingDto(null, 20); // cursor 없음, size=20
@@ -219,14 +223,14 @@ class DmServiceImplTest {
     // 커서 조회 결과는 dm1, dm2
     given(dmRepositoryCustom.findByCursor(eq(roomId), anyInt(), any(), any()))
         .willReturn(list.subList(0, 21));
-    given(dmRepository.count()).willReturn(20L);
+    given(dmRepository.countByDmRoomId(roomId)).willReturn(40L);
 
     // when
     var pagingDto = new DmPagingDto(null, 20); // cursor 없음, size=20
     var result = dmService.getDmList(roomId, pagingDto, userB);
 
     // then
-    assertThat(result.data()).hasSize(21);
+    assertThat(result.data()).hasSize(20);
     assertThat(result.hasNext()).isTrue();
   }
 


### PR DESCRIPTION
## 🛰️ Issue Number

- #280 

## 🪐 작업 내용
dm 페이징 시 CursorUtils의 엔코딩 수행하고 반환하도록 수정

- CursorCodecUtil 에 Dm 관련 encoding 로직 추가
- DmRepository 에서 dm.createdAt.lt -> dm.createdAt.loe
  -  20개 요청 -> 21개까지 탐색 후 nextCursor 21번째 전달 -> 21번째부터 찾기
- CursorCodecUtil 를 통해 인코딩 후 반환하도록 수정

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?