### PR TITLE
fix: 리뷰 중복 예외 처리 수정

### DIFF
--- a/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/review/service/ReviewServiceImpl.java
@@ -42,14 +42,14 @@ public class ReviewServiceImpl implements ReviewService {
 
     Content content = contentRepository.findById(request.contentId())
         .orElseThrow(() -> {
-          log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: {}", request.contentId());
+          log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID = {}", request.contentId());
           return new ContentNotFoundException();
         });
 
-    reviewRepository.findByUserId(user.getId()).ifPresent(review -> {
-      log.warn("이미 리뷰를 작성한 사용자입니다. 사용자 ID: {}", user.getId());
+    if (reviewRepository.existsByUserIdAndContentId(user.getId(), content.getId())) {
+      log.warn("이미 해당 콘텐츠에 리뷰를 작성했습니다. 콘텐츠 ID = {}, 사용자 ID = {}", user.getId(), content.getId());
       throw new DuplicateReviewException();
-    });
+    }
 
     Review review = Review.builder()
         .user(user)
@@ -74,7 +74,7 @@ public class ReviewServiceImpl implements ReviewService {
         .orElseThrow(ReviewNotFoundException::new);
 
     if (!review.getUser().getId().equals(userId)) {
-      log.warn("리뷰 작성자만 수정할 수 있습니다. 요청 유저 ID: {}, 리뷰 작성자 ID: {}",
+      log.warn("리뷰 작성자만 수정할 수 있습니다. 요청 유저 ID = {}, 리뷰 작성자 ID = {}",
           userId, review.getUser().getId());
       throw new ReviewUpdateDeniedException();
     }
@@ -99,7 +99,7 @@ public class ReviewServiceImpl implements ReviewService {
   @Override
   public List<ReviewDto> getAllByUser(UUID userId) {
     if (!userRepository.existsById(userId)) {
-      log.warn("존재하지 않는 유저입니다. 유저 ID: {}", userId);
+      log.warn("존재하지 않는 유저입니다. 유저 ID = {}", userId);
       throw new UserNotFoundException();
     }
 
@@ -111,7 +111,7 @@ public class ReviewServiceImpl implements ReviewService {
   @Transactional(readOnly = true)
   public List<ReviewDto> getAllByContent(UUID contentId) {
     if (!contentRepository.existsById(contentId)) {
-      log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID: {}", contentId);
+      log.warn("존재하지 않는 콘텐츠입니다. 콘텐츠 ID = {}", contentId);
       throw new ContentNotFoundException();
     }
 
@@ -126,7 +126,7 @@ public class ReviewServiceImpl implements ReviewService {
         .orElseThrow(ReviewNotFoundException::new);
 
     if (!review.getUser().getId().equals(userId)) {
-      log.warn("리뷰 작성자만 삭제할 수 있습니다. 요청 유저 ID: {}, 리뷰 작성자 ID: {}",
+      log.warn("리뷰 작성자만 삭제할 수 있습니다. 요청 유저 ID = {}, 리뷰 작성자 ID = {}",
           userId, review.getUser().getId());
       throw new ReviewDeleteDeniedException();
     }


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->

## 🪐 작업 내용
- 동일 사용자가 동일 콘텐츠에 리뷰 남겼을 때 예외처리가 이상하여 수정하였습니다

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?