### PR TITLE
fix: 시청방 예상 딜레이 시간 추가

### DIFF
--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -280,7 +280,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     Double nowPlayTime =
         (double) Duration.between(watchRoom.getVideoStateUpdatedAt(), LocalDateTime.now())
-            .toSeconds() + watchRoom.getPlayTime();
+            .toSeconds() + watchRoom.getPlayTime() + 1.3;
 
     return WatchRoomInfoDto.builder()
         .id(watchRoom.getId())

--- a/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
@@ -536,11 +537,14 @@ class WatchRoomServiceImplTest {
                 .build();
           }).toList();
 
+      LocalDateTime videoStateUpdatedAt = LocalDateTime.now();
+
       UUID chatRoomId = UUID.randomUUID();
       WatchRoom watchRoom = WatchRoom.builder()
           .id(chatRoomId)
           .title("테스트용 시청방")
           .playTime(1.0)
+          .videoStateUpdatedAt(videoStateUpdatedAt)
           .isPlaying(true)
           .owner(user)
           .content(content)
@@ -554,9 +558,13 @@ class WatchRoomServiceImplTest {
       ParticipantsInfoDto participantsInfoDto = new ParticipantsInfoDto(participantDtos,
           participantDtos.size());
 
+      Double expectedNowPlayTime =
+          (double) Duration.between(watchRoom.getVideoStateUpdatedAt(), LocalDateTime.now())
+              .toSeconds() + watchRoom.getPlayTime() + 1.3;
+
       WatchRoomInfoDto expected = WatchRoomInfoDto.builder()
           .id(chatRoomId)
-          .playTime(1.0)
+          .playTime(expectedNowPlayTime)
           .isPlaying(true)
           .content(ContentDto.from(content))
           .participantsInfoDto(participantsInfoDto)
@@ -579,7 +587,7 @@ class WatchRoomServiceImplTest {
       assertEquals(expected.id(), watchRoomInfoDto.id());
       assertEquals(expected.content().title(), watchRoomInfoDto.content().title());
       assertTrue(watchRoomInfoDto.isPlaying());
-      assertEquals(1.0, watchRoomInfoDto.playTime());
+      assertEquals(expectedNowPlayTime, watchRoomInfoDto.playTime());
       assertEquals(expected.participantsInfoDto().participantCount(),
           watchRoomInfoDto.participantsInfoDto().participantCount());
 


### PR DESCRIPTION
## 🛰️ Issue Number

- 시청방 중도 입장시 딜레이 발생하는 문제

## 🪐 작업 내용
- 예상 딜레이 시간 추가
- 테스트 코드 수정


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?