### PR TITLE
fix: 시청방 예상 딜레이 시간 추가 main에 반영

### DIFF
--- a/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/follow/service/FollowServiceImpl.java
@@ -57,7 +57,7 @@ public class FollowServiceImpl implements FollowService {
 
     // 알림 전송 추가
     notificationService.sendNotification(
-        new NotificationDto(following.getId(), NotificationType.FOLLOWED,
+        new NotificationDto(followingId, NotificationType.FOLLOWED,
             follower.getName()+ "이(가) "+following.getName()+"를 팔로우 했습니다.", false));
     log.info("follow - 팔로우 성공: followerId={}, followingId={}", followerId, followingId);
   }

--- a/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
+++ b/src/main/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImpl.java
@@ -280,7 +280,7 @@ public class WatchRoomServiceImpl implements WatchRoomService {
 
     Double nowPlayTime =
         (double) Duration.between(watchRoom.getVideoStateUpdatedAt(), LocalDateTime.now())
-            .toSeconds() + watchRoom.getPlayTime();
+            .toSeconds() + watchRoom.getPlayTime() + 1.3;
 
     return WatchRoomInfoDto.builder()
         .id(watchRoom.getId())

--- a/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
+++ b/src/test/java/team03/mopl/domain/watchroom/service/WatchRoomServiceImplTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
@@ -536,11 +537,14 @@ class WatchRoomServiceImplTest {
                 .build();
           }).toList();
 
+      LocalDateTime videoStateUpdatedAt = LocalDateTime.now();
+
       UUID chatRoomId = UUID.randomUUID();
       WatchRoom watchRoom = WatchRoom.builder()
           .id(chatRoomId)
           .title("테스트용 시청방")
           .playTime(1.0)
+          .videoStateUpdatedAt(videoStateUpdatedAt)
           .isPlaying(true)
           .owner(user)
           .content(content)
@@ -554,9 +558,13 @@ class WatchRoomServiceImplTest {
       ParticipantsInfoDto participantsInfoDto = new ParticipantsInfoDto(participantDtos,
           participantDtos.size());
 
+      Double expectedNowPlayTime =
+          (double) Duration.between(watchRoom.getVideoStateUpdatedAt(), LocalDateTime.now())
+              .toSeconds() + watchRoom.getPlayTime() + 1.3;
+
       WatchRoomInfoDto expected = WatchRoomInfoDto.builder()
           .id(chatRoomId)
-          .playTime(1.0)
+          .playTime(expectedNowPlayTime)
           .isPlaying(true)
           .content(ContentDto.from(content))
           .participantsInfoDto(participantsInfoDto)
@@ -579,7 +587,7 @@ class WatchRoomServiceImplTest {
       assertEquals(expected.id(), watchRoomInfoDto.id());
       assertEquals(expected.content().title(), watchRoomInfoDto.content().title());
       assertTrue(watchRoomInfoDto.isPlaying());
-      assertEquals(1.0, watchRoomInfoDto.playTime());
+      assertEquals(expectedNowPlayTime, watchRoomInfoDto.playTime());
       assertEquals(expected.participantsInfoDto().participantCount(),
           watchRoomInfoDto.participantsInfoDto().participantCount());
 


### PR DESCRIPTION
## 🛰️ Issue Number

<!-- 예시
- #11 
-->

## 🪐 작업 내용
<!-- 예시
- Interest 생성(Create) 기능
  - 유사도 계산하여 유사도가 80%미만인 경우에만 등록 가능하도록 구현
  - 테스트 코드 추가
- 관심사 삭제 기능 추가
  - 기본적인 삭제 구현
  - 테스트 코드 추가
 -->

## 📚 Reference
<!-- 예시
- [퇴근 후 문자열 유사성 알고리즘 적용해서 업무 개선해보기](https://velog.io/@h-go-getter/%ED%87%B4%EA%B7%BC-%ED%9B%84-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%9C%A0%EC%82%AC%EC%84%B1-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EC%A0%81%EC%9A%A9%ED%95%B4%EC%84%9C-%EC%97%85%EB%AC%B4-%EA%B0%9C%EC%84%A0%ED%95%B4%EB%B3%B4%EA%B8%B0)
- [복합키 구현](https://syk531.tistory.com/94)
-->

## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?